### PR TITLE
add GitHub CLI to runner image

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -20,6 +20,7 @@ RUN apt update -y \
     dnsutils \
     ftp \
     git \
+    gpg \
     iproute2 \
     iputils-ping \
     jq \
@@ -116,6 +117,16 @@ COPY --chown=runner:docker patched $RUNNER_ASSETS_DIR/patched
 # Add the Python "User Script Directory" to the PATH
 ENV PATH="${PATH}:${HOME}/.local/bin"
 ENV ImageOS=ubuntu20
+
+# install GitHub CLI
+RUN curl -fsSL \
+    https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+    gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    tee /etc/apt/sources.list.d/github-cli.list
+RUN apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
 
 USER runner
 


### PR DESCRIPTION
Add the GitHub CLI so it can be used in workflows. This should be useful to a wide audience and is included in the official GitHub runners. I have tried out this image in my infrastructure and it works for me.