### PR TITLE
fix: cast so int and string supported

### DIFF
--- a/charts/actions-runner-controller/templates/manager_secrets.yaml
+++ b/charts/actions-runner-controller/templates/manager_secrets.yaml
@@ -8,11 +8,13 @@ metadata:
     {{- include "actions-runner-controller.labels" . | nindent 4 }}
 type: Opaque
 data:
+# cast attribute like this so it can be provided as an int or string in values.yaml
 {{- if .Values.authSecret.github_app_id }}
-  github_app_id: {{ .Values.authSecret.github_app_id | int | toString | b64enc }}
+  github_app_id: {{ int .Values.authSecret.github_app_id | toString | b64enc }}
 {{- end }}
+# cast attribute like this so it can be provided as an int or string in values.yaml
 {{- if .Values.authSecret.github_app_installation_id }}
-  github_app_installation_id: {{ .Values.authSecret.github_app_installation_id | int | toString | b64enc }}
+  github_app_installation_id: {{ int .Values.authSecret.github_app_installation_id | toString | b64enc }}
 {{- end }}
 {{- if .Values.authSecret.github_app_private_key }}
   github_app_private_key: {{ .Values.authSecret.github_app_private_key | toString | b64enc }}


### PR DESCRIPTION
**Context** https://github.com/actions-runner-controller/actions-runner-controller/pull/883
**Fixes** https://github.com/actions-runner-controller/actions-runner-controller/issues/882

@apr-1985 how do you feel about this as a compromise? Having gone through the Helm docs and tested this PR it seems to work fine. I was able to deploy a controller onto a kind cluster with my auth config set as either of the below:

```yaml
github_app_id: "1111111"
github_app_installation_id: "1111111"
github_app_private_key: |
  -----BEGIN RSA PRIVATE KEY-----
  ......
```

```yaml
github_app_id: 1111111
github_app_installation_id: 1111111
github_app_private_key: |
  -----BEGIN RSA PRIVATE KEY-----
  ......
```