### PR TITLE
docs: Update examples of RunnerDeployment in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,9 @@ kind: RunnerDeployment
 metadata:
    name: myrunners
 spec:
-  repository: example/myrepo
+  template:
+    spec:
+      repository: example/myrepo
 ---
 kind: HorizontalRunnerAutoscaler
 spec:
@@ -610,7 +612,9 @@ kind: RunnerDeployment
 metadata:
    name: myrunners
 spec:
-  repository: example/myrepo
+  template:
+    spec:
+      repository: example/myrepo
 ---
 kind: HorizontalRunnerAutoscaler
 spec:
@@ -632,7 +636,9 @@ kind: RunnerDeployment
 metadata:
    name: myrunners
 spec:
-  organization: myorg
+  template:
+    spec:
+      organization: myorg
 ---
 kind: HorizontalRunnerAutoscaler
 spec:
@@ -658,7 +664,9 @@ kind: RunnerDeployment
 metadata:
    name: myrunners
 spec:
-  repository: example/myrepo
+  template:
+    spec:
+      repository: example/myrepo
 ---
 kind: HorizontalRunnerAutoscaler
 spec:


### PR DESCRIPTION
The README had some examples of `RunnerDeployment` with wrong/outdated
spec.

This caused some pain when trying to create them based on the examples.

=> Fixed using the spec declared in: [api/v1alpha1/runner_types.go](https://github.com/actions-runner-controller/actions-runner-controller/blob/v0.20.1/api/v1alpha1/runner_types.go#L29)