### PR TITLE
Added workflow to be triggered via rest api dispatch in e2e test

### DIFF
--- a/.github/workflows/e2e-test-dispatch-workflow.yaml
+++ b/.github/workflows/e2e-test-dispatch-workflow.yaml
@@ -1,0 +1,16 @@
+name: ARC-REUSABLE-WORKFLOW
+on:
+  workflow_dispatch:
+    inputs:
+      date_time:
+        description: 'Datetime for runner name uniqueness, format: %Y-%m-%d-%H-%M-%S-%3N, example: 2023-02-14-13-00-16-791'
+        required: true
+jobs:
+  arc-runner-job:
+    strategy:
+      fail-fast: false
+      matrix:
+        job: [1, 2, 3]
+    runs-on: arc-runner-${{ inputs.date_time }}
+    steps:
+      - run: echo "Hello World!" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Part of [Linux VM testing](https://github.com/github/c2c-actions-runtime/issues/2195) - added before the rest of the steps as we'll use this workflow ID in the rest API /dispatches call