### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/charts/gha-runner-scale-set-controller/Chart.yaml
+++ b/charts/gha-runner-scale-set-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/gha-runner-scale-set/Chart.yaml
+++ b/charts/gha-runner-scale-set/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 
 home: https://github.com/actions/dev-arc
 

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -149,6 +149,24 @@ Upgrading actions-runner-controller requires a few extra steps because CRDs will
 
 ## Troubleshooting
 
+### I'm using the charts from the `master` branch and the controller is not working
+
+The `master` branch is highly unstable! We offer no guarantees that the charts in the `master` branch will work at any given time. If you're using the charts from the `master` branch, you should expect to encounter issues. Please use the latest release instead.
+
+### Controller pod is running but the runner set listener pod is not
+
+You need to inspect the logs of the controller first and see if there are any errors. If there are no errors, and the runner set listener pod is still not running, you need to make sure that the **controller pod has access to the Kubernetes API server in your cluster!**
+
+You'll see something similar to the following in the logs of the controller pod:
+
+```log
+kubectl logs <controller_pod_name> -c manager
+17:35:28.661069       1 request.go:690] Waited for 1.032376652s due to client-side throttling, not priority and fairness, request: GET:https://10.0.0.1:443/apis/monitoring.coreos.com/v1alpha1?timeout=32s
+2023-03-15T17:35:29Z    INFO    starting manager
+```
+
+If you have a proxy configured or you're using a sidecar proxy that's automatically injected (think [Istio](https://istio.io/)), you need to make sure it's configured appropriately to allow traffic from the controller container (manager) to the Kubernetes API server.
+
 ### Check the logs
 
 You can check the logs of the controller pod using the following command:

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -221,20 +221,21 @@ To fix this, you can either:
 
 ### v0.4.0
 
+#### ⚠️ Warning
 
-#### Warning
+This release contains a major change related to the way permissions are
+applied to the manager ([#2276](https://github.com/actions/actions-runner-controller/pull/2276) and [#2363](https://github.com/actions/actions-runner-controller/pull/2363)).
 
-This release contains a breaking change related to the way permissions are
-applied to the manager. Please evaluate these changes carefully before upgrading.
+Please evaluate these changes carefully before upgrading.
 
 #### Major changes
 
 1. Surface EphemeralRunnerSet stats to AutoscalingRunnerSet [#2382](https://github.com/actions/actions-runner-controller/pull/2382)
-1. Remove list/watch secrets permission from manager cluster role
+1. Improved security posture by removing list/watch secrets permission from manager cluster role
    [#2276](https://github.com/actions/actions-runner-controller/pull/2276)
-1. Delay role/rolebinding creation to gha-runner-scale-set during installation
+1. Improved security posture by delaying role/rolebinding creation to gha-runner-scale-set during installation
    [#2363](https://github.com/actions/actions-runner-controller/pull/2363)
-1. Support watching a single namespace from the controller
+1. Improved security posture by supporting watching a single namespace from the controller
    [#2374](https://github.com/actions/actions-runner-controller/pull/2374)
 1. Add labels to AutoscalingRunnerSet subresources to allow easier inspection [#2391](https://github.com/actions/actions-runner-controller/pull/2391)
 1. Fix bug preventing env variables from being specified

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -264,6 +264,7 @@ Please evaluate these changes carefully before upgrading.
    [#2418](https://github.com/actions/actions-runner-controller/pull/2418)
 1. Added additional cleanup finalizers [#2433](https://github.com/actions/actions-runner-controller/pull/2433)
 1. gha-runner-scale-set listener pod inherits the ImagePullPolicy from the manager pod [#2477](https://github.com/actions/actions-runner-controller/pull/2477)
+1. Treat `.ghe.com` domain as hosted environment [#2480](https://github.com/actions/actions-runner-controller/pull/2480)
 
 ### v0.3.0
 

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -262,6 +262,7 @@ Please evaluate these changes carefully before upgrading.
    [#2435](https://github.com/actions/actions-runner-controller/pull/2435)
 1. Fix ignore extra dind container when container mode type is "dind"
    [#2418](https://github.com/actions/actions-runner-controller/pull/2418)
+1. Add additional cleanup finalizers [#2433](https://github.com/actions/actions-runner-controller/pull/2433)
 
 ### v0.3.0
 

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -263,6 +263,7 @@ Please evaluate these changes carefully before upgrading.
 1. Fixed ignore extra dind container when container mode type is "dind"
    [#2418](https://github.com/actions/actions-runner-controller/pull/2418)
 1. Added additional cleanup finalizers [#2433](https://github.com/actions/actions-runner-controller/pull/2433)
+1. gha-runner-scale-set listener pod inherits the ImagePullPolicy from the manager pod [#2477](https://github.com/actions/actions-runner-controller/pull/2477)
 
 ### v0.3.0
 

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -36,7 +36,7 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
         --namespace "${NAMESPACE}" \
         --create-namespace \
         oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller \
-        --version 0.3.0
+        --version 0.4.0
     ```
 
 1. Generate a Personal Access Token (PAT) or create and install a GitHub App. See [Creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and [Creating a GitHub App](https://docs.github.com/en/developers/apps/creating-a-github-app).
@@ -57,7 +57,7 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
         --create-namespace \
         --set githubConfigUrl="${GITHUB_CONFIG_URL}" \
         --set githubConfigSecret.github_token="${GITHUB_PAT}" \
-        oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --version 0.3.0
+        oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --version 0.4.0
     ```
 
     ```bash
@@ -75,7 +75,7 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
         --set githubConfigSecret.github_app_id="${GITHUB_APP_ID}" \
         --set githubConfigSecret.github_app_installation_id="${GITHUB_APP_INSTALLATION_ID}" \
         --set githubConfigSecret.github_app_private_key="${GITHUB_APP_PRIVATE_KEY}" \
-        oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --version 0.3.0
+        oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --version 0.4.0
     ```
 
 1. Check your installation. If everything went well, you should see the following:
@@ -84,8 +84,8 @@ https://user-images.githubusercontent.com/568794/212668313-8946ddc5-60c1-461f-a7
     $ helm list -n "${NAMESPACE}"
 
     NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                    APP VERSION
-    arc             arc-systems     1               2023-01-18 10:03:36.610534934 +0000 UTC deployed        gha-runner-scale-set-controller-0.3.0        preview
-    arc-runner-set  arc-systems     1               2023-01-18 10:20:14.795285645 +0000 UTC deployed        gha-runner-scale-set-0.3.0            0.3.0
+    arc             arc-systems     1               2023-01-18 10:03:36.610534934 +0000 UTC deployed        gha-runner-scale-set-controller-0.4.0        preview
+    arc-runner-set  arc-systems     1               2023-01-18 10:20:14.795285645 +0000 UTC deployed        gha-runner-scale-set-0.4.0            0.4.0
     ```
 
     ```bash
@@ -140,7 +140,7 @@ Upgrading actions-runner-controller requires a few extra steps because CRDs will
 
     ```bash
     helm pull oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller \
-        --version 0.3.0 \
+        --version 0.4.0 \
         --untar && \
         kubectl replace -f <PATH>/gha-runner-scale-set-controller/crds/
     ```
@@ -218,6 +218,25 @@ To fix this, you can either:
     ```
 
 ## Changelog
+
+### v0.4.0
+
+#### Major changes
+
+1. Surface EphemeralRunnerSet stats to AutoscalingRunnerSet [#2382](https://github.com/actions/actions-runner-controller/pull/2382)
+1. Remove list/watch secrets permission from manager cluster role
+   [#2276](https://github.com/actions/actions-runner-controller/pull/2276)
+1. Delay role/rolebinding creation to gha-runner-scale-set during installation
+   [#2363](https://github.com/actions/actions-runner-controller/pull/2363)
+1. Support watching a single namespace from the controller
+   [#2374](https://github.com/actions/actions-runner-controller/pull/2374)
+1. Add labels to AutoscalingRunnerSet subresources to allow easier inspection [#2391](https://github.com/actions/actions-runner-controller/pull/2391)
+1. Fix bug preventing env variables from being specified
+   [#2450](https://github.com/actions/actions-runner-controller/pull/2450)
+1. Enhance quickstart troubleshooting guides
+   [#2435](https://github.com/actions/actions-runner-controller/pull/2435)
+1. Fix ignore extra dind container when container mode type is "dind"
+   [#2418](https://github.com/actions/actions-runner-controller/pull/2418)
 
 ### v0.3.0
 

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -255,14 +255,14 @@ Please evaluate these changes carefully before upgrading.
    [#2363](https://github.com/actions/actions-runner-controller/pull/2363)
 1. Improved security posture by supporting watching a single namespace from the controller
    [#2374](https://github.com/actions/actions-runner-controller/pull/2374)
-1. Add labels to AutoscalingRunnerSet subresources to allow easier inspection [#2391](https://github.com/actions/actions-runner-controller/pull/2391)
-1. Fix bug preventing env variables from being specified
+1. Added labels to AutoscalingRunnerSet subresources to allow easier inspection [#2391](https://github.com/actions/actions-runner-controller/pull/2391)
+1. Fixed bug preventing env variables from being specified
    [#2450](https://github.com/actions/actions-runner-controller/pull/2450)
 1. Enhance quickstart troubleshooting guides
    [#2435](https://github.com/actions/actions-runner-controller/pull/2435)
-1. Fix ignore extra dind container when container mode type is "dind"
+1. Fixed ignore extra dind container when container mode type is "dind"
    [#2418](https://github.com/actions/actions-runner-controller/pull/2418)
-1. Add additional cleanup finalizers [#2433](https://github.com/actions/actions-runner-controller/pull/2433)
+1. Added additional cleanup finalizers [#2433](https://github.com/actions/actions-runner-controller/pull/2433)
 
 ### v0.3.0
 

--- a/docs/preview/gha-runner-scale-set-controller/README.md
+++ b/docs/preview/gha-runner-scale-set-controller/README.md
@@ -221,6 +221,12 @@ To fix this, you can either:
 
 ### v0.4.0
 
+
+#### Warning
+
+This release contains a breaking change related to the way permissions are
+applied to the manager. Please evaluate these changes carefully before upgrading.
+
 #### Major changes
 
 1. Surface EphemeralRunnerSet stats to AutoscalingRunnerSet [#2382](https://github.com/actions/actions-runner-controller/pull/2382)


### PR DESCRIPTION
Notable changes (Excluding tests):
- #2382
- #2276
- #2363
- #2374
- #2391
- #2450
- #2435
- #2418
- #2433
- #2477
- #2480