### PR TITLE
Replace all `arc-systems` occurences in favor of `arc-system`

### DIFF
--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -50,7 +50,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -58,7 +58,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -70,9 +70,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -88,7 +88,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -100,8 +100,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -113,7 +113,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   single-namespace-setup:
     runs-on: ubuntu-latest
@@ -140,7 +140,7 @@ jobs:
         run: |
           kubectl create namespace arc-runners
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -149,7 +149,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -161,9 +161,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -179,7 +179,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -191,8 +191,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -204,7 +204,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   dind-mode-setup:
     runs-on: ubuntu-latest
@@ -230,7 +230,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -238,7 +238,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -250,9 +250,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -269,7 +269,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -281,8 +281,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -294,7 +294,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   kubernetes-mode-setup:
     runs-on: ubuntu-latest
@@ -325,7 +325,7 @@ jobs:
           helm install openebs openebs/openebs -n openebs --create-namespace
 
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -333,7 +333,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -345,9 +345,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
           kubectl wait --timeout=30s --for=condition=ready pod -n openebs -l name=openebs-localpv-provisioner
 
       - name: Install gha-runner-scale-set
@@ -368,7 +368,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -380,8 +380,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -393,7 +393,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   auth-proxy-setup:
     runs-on: ubuntu-latest
@@ -419,7 +419,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -427,7 +427,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -439,9 +439,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -469,7 +469,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -481,8 +481,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -494,7 +494,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   anonymous-proxy-setup:
     runs-on: ubuntu-latest
@@ -520,7 +520,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -528,7 +528,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -540,9 +540,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -564,7 +564,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -576,8 +576,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -589,7 +589,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   self-signed-ca-setup:
     runs-on: ubuntu-latest
@@ -615,7 +615,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -623,7 +623,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -635,9 +635,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -684,7 +684,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -696,8 +696,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -709,7 +709,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
 
   update-strategy-tests:
     runs-on: ubuntu-latest
@@ -735,7 +735,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -744,7 +744,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -756,9 +756,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -774,7 +774,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -786,8 +786,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
 
       - name: Trigger long running jobs and wait for runners to pick them up
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -799,7 +799,7 @@ jobs:
           workflow-file: ${{env.WORKFLOW_FILE}}
           arc-name: ${{steps.install_arc.outputs.ARC_NAME}}
           arc-namespace: "arc-runners"
-          arc-controller-namespace: "arc-systems"
+          arc-controller-namespace: "arc-system"
           wait-to-running: "true"
           wait-to-finish: "false"
 
@@ -824,7 +824,7 @@ jobs:
         run: |
           count=0
           while true; do
-            LISTENER_COUNT="$(kubectl get pods -l actions.github.com/scale-set-name=${{ steps.install_arc.outputs.ARC_NAME }} -n arc-systems --field-selector=status.phase=Running -o=jsonpath='{.items}' | jq 'length')"
+            LISTENER_COUNT="$(kubectl get pods -l actions.github.com/scale-set-name=${{ steps.install_arc.outputs.ARC_NAME }} -n arc-system --field-selector=status.phase=Running -o=jsonpath='{.items}' | jq 'length')"
             RUNNERS_COUNT="$(kubectl get pods -l app.kubernetes.io/component=runner -n arc-runners --field-selector=status.phase=Running -o=jsonpath='{.items}' | jq 'length')"
             RESOURCES="$(kubectl get pods -A)"
 
@@ -851,7 +851,7 @@ jobs:
         run: |
           count=0
           while true; do
-            LISTENER_COUNT="$(kubectl get pods -l actions.github.com/scale-set-name=${{ steps.install_arc.outputs.ARC_NAME }} -n arc-systems --field-selector=status.phase=Running -o=jsonpath='{.items}' | jq 'length')"
+            LISTENER_COUNT="$(kubectl get pods -l actions.github.com/scale-set-name=${{ steps.install_arc.outputs.ARC_NAME }} -n arc-system --field-selector=status.phase=Running -o=jsonpath='{.items}' | jq 'length')"
             RUNNERS_COUNT="$(kubectl get pods -l app.kubernetes.io/component=runner -n arc-runners --field-selector=status.phase=Running -o=jsonpath='{.items}' | jq 'length')"
             RESOURCES="$(kubectl get pods -A)"
 
@@ -879,7 +879,7 @@ jobs:
         run: |
           helm uninstall "${{ steps.install_arc.outputs.ARC_NAME }}" --namespace "arc-runners" --debug
           kubectl wait --timeout=10s --for=delete AutoScalingRunnerSet -n "${{ steps.install_arc.outputs.ARC_NAME }}" -l app.kubernetes.io/instance="${{ steps.install_arc.outputs.ARC_NAME }}"
-          kubectl logs deployment/arc-gha-rs-controller -n "arc-systems"
+          kubectl logs deployment/arc-gha-rs-controller -n "arc-system"
 
   init-with-min-runners:
     runs-on: ubuntu-latest
@@ -905,7 +905,7 @@ jobs:
         id: install_arc_controller
         run: |
           helm install arc \
-          --namespace "arc-systems" \
+          --namespace "arc-system" \
           --create-namespace \
           --set image.repository=${{ env.IMAGE_NAME }} \
           --set image.tag=${{ env.IMAGE_VERSION }} \
@@ -914,7 +914,7 @@ jobs:
           --debug
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l app.kubernetes.io/name=gha-rs-controller -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l app.kubernetes.io/name=gha-rs-controller -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -926,9 +926,9 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l app.kubernetes.io/name=gha-rs-controller
-          kubectl get pod -n arc-systems
-          kubectl describe deployment arc-gha-rs-controller -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l app.kubernetes.io/name=gha-rs-controller
+          kubectl get pod -n arc-system
+          kubectl describe deployment arc-gha-rs-controller -n arc-system
 
       - name: Install gha-runner-scale-set
         id: install_arc
@@ -945,7 +945,7 @@ jobs:
           echo "ARC_NAME=$ARC_NAME" >> $GITHUB_OUTPUT
           count=0
           while true; do
-            POD_NAME=$(kubectl get pods -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME -o name)
+            POD_NAME=$(kubectl get pods -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME -o name)
             if [ -n "$POD_NAME" ]; then
               echo "Pod found: $POD_NAME"
               break
@@ -957,8 +957,8 @@ jobs:
             sleep 1
             count=$((count+1))
           done
-          kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
-          kubectl get pod -n arc-systems
+          kubectl wait --timeout=30s --for=condition=ready pod -n arc-system -l actions.github.com/scale-set-name=$ARC_NAME
+          kubectl get pod -n arc-system
       - name: Ensure 5 runners are up
         run: |
           count=0

--- a/test_e2e_arc/arc_jobs_test.go
+++ b/test_e2e_arc/arc_jobs_test.go
@@ -24,7 +24,7 @@ type podCountsByType struct {
 }
 
 func getPodsByType(clientset *kubernetes.Clientset) podCountsByType {
-	arc_namespace := "arc-systems"
+	arc_namespace := "arc-system"
 	availableArcPods, err := clientset.CoreV1().Pods(arc_namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
# Description

In this repo we can find `arc-systems` and `arc-system`. To avoid confusion and inconsistency, I propose we always use `arc-system` singular as it's more common in the repo and the old [`actions-runner-system`](https://github.com/actions/actions-runner-controller/blob/master/charts/actions-runner-controller/docs/UPGRADING.md#:~:text=actions%2Drunner%2Dsystem) was always used in the singular. I'm ignorant about what generated the use of singular and plural in this repo.

7 files in total have `arc-system` or `arc-systems`:
![image](https://github.com/actions/actions-runner-controller/assets/29926675/ead89723-9a37-4f97-9a02-c7fb03635467)
