### PR TITLE
Add list verb over secrets for the controller, required when deleting ephemeralrunners

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/manager_listener_role.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/manager_listener_role.yaml
@@ -28,6 +28,7 @@ rules:
   - get
   - patch
   - update
+  - list
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Controller requires `list` permission over secrets in the watched namespace when deleting `ephemeralrunner` resources.
When not granted `ephemeralrunner` resources cannot be deleted by the controller printing next error:
```
2024-05-09T09:54:33Z    ERROR    Reconciler error    {"controller": "ephemeral-runner-controller", "controllerGroup": "actions.github.com", "controllerKind": "EphemeralRunner", "EphemeralRunner": {"name":"<POD_NAME>","namespace":"<NAMESPACE_NAME>"}, "namespace": "<NAMESPACE_NAME>", "name": "<POD_NAME>", "reconcileID": "44cd28a5-ecd0-4334-9c9c-4decde0a39d8", "error": "failed to list runner-linked secrets: secrets is forbidden: User \"system:serviceaccount:<NAMESPACE_NAME>:arc-gha-rs-controller\" cannot list resource \"secrets\" in API group \"\" in the namespace \"<NAMESPACE_NAME>\""}
```