### PR TITLE
Custom dind config and node tolerations for runner pod

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -96,11 +96,17 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+image: {{ default "docker:dind" .Values.dindConfig.image }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
+  {{- if .Values.dindConfig.bip }}
+  - --bip={{ .Values.dindConfig.bip }}
+  {{- end }}
+  {{- if .Values.dindConfig.defaultAddressPool }}
+  - --default-address-pool=base={{ .Values.dindConfig.defaultAddressPool.base}},size={{ .Values.dindConfig.defaultAddressPool.size}}
+  {{- end }}
 env:
   - name: DOCKER_GROUP_GID
     value: "123"

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -164,3 +164,19 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -88,6 +88,14 @@ githubConfigSecret:
 #   kubernetesModeServiceAccount:
 #     annotations:
 
+## The following is the customization for dind image and network configuration
+# dindConfig:
+#   image: docker:20.10.7-dind
+#   bip: 192.168.200.1/24
+#   defaultAddressPool:
+#     base: 192.168.201.1/24
+#     size: 24
+
 ## listenerTemplate is the PodSpec for each listener Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
 # listenerTemplate:
@@ -201,3 +209,11 @@ template:
 # controllerServiceAccount:
 #   namespace: arc-system
 #   name: test-arc-gha-runner-scale-set-controller
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+topologySpreadConstraints: []


### PR DESCRIPTION
## Changes

- Add custom dind config to allow private registry images to be used in dind container
- Allows dind container to use a custom network range to avoid conflicting IPs with IP ranges in cloud provider like AWS
- Use node tolerations for runner pod to have more flexibility in scheduling the required pods 