### PR TITLE
Fix ARC e2e tests

### DIFF
--- a/.github/actions/execute-assert-arc-e2e/action.yaml
+++ b/.github/actions/execute-assert-arc-e2e/action.yaml
@@ -199,4 +199,11 @@ runs:
       shell: bash
       if: always()
       run: |
+        echo "::group::Controller logs"
         kubectl logs deployment/arc-gha-rs-controller -n ${{inputs.arc-controller-namespace}}
+        echo "::endgroup::"
+
+        echo "::group::Listener logs"
+        LISTENER_POD="$(kubectl get autoscalinglisteners.actions.github.com -n arc-systems -o jsonpath='{.items[*].metadata.name}'))"
+        kubectl logs $LISTENER_POD -n ${{inputs.arc-controller-namespace}}
+        echo "::endgroup::"

--- a/.github/actions/execute-assert-arc-e2e/action.yaml
+++ b/.github/actions/execute-assert-arc-e2e/action.yaml
@@ -188,6 +188,19 @@ runs:
           }
           core.setFailed(`The triggered workflow run didn't finish properly using ${{inputs.arc-name}}`)
 
+    - name: Gather listener logs
+      shell: bash
+      if: always()
+      run: |
+        LISTENER_POD="$(kubectl get autoscalinglisteners.actions.github.com -n arc-systems -o jsonpath='{.items[*].metadata.name}')"
+        kubectl logs $LISTENER_POD -n ${{inputs.arc-controller-namespace}}
+    
+    - name: Gather coredns logs
+      shell: bash
+      if: always()
+      run: |
+        kubectl logs deployments/coredns -n kube-system 
+
     - name: cleanup
       if: inputs.wait-to-finish == 'true'
       shell: bash
@@ -195,15 +208,8 @@ runs:
         helm uninstall ${{ inputs.arc-name }} --namespace ${{inputs.arc-namespace}} --debug
         kubectl wait --timeout=30s --for=delete AutoScalingRunnerSet -n ${{inputs.arc-namespace}} -l app.kubernetes.io/instance=${{ inputs.arc-name }}
 
-    - name: Gather logs and cleanup
+    - name: Gather controller logs
       shell: bash
       if: always()
       run: |
-        echo "::group::Controller logs"
         kubectl logs deployment/arc-gha-rs-controller -n ${{inputs.arc-controller-namespace}}
-        echo "::endgroup::"
-
-        echo "::group::Listener logs"
-        LISTENER_POD="$(kubectl get autoscalinglisteners.actions.github.com -n arc-systems -o jsonpath='{.items[*].metadata.name}'))"
-        kubectl logs $LISTENER_POD -n ${{inputs.arc-controller-namespace}}
-        echo "::endgroup::"

--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -103,6 +103,8 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
+          sleep 60
+
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
         timeout-minutes: 10
@@ -194,6 +196,8 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
+          sleep 60
+
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
         timeout-minutes: 10
@@ -283,6 +287,8 @@ jobs:
           done
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
+
+          sleep 60
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -382,6 +388,8 @@ jobs:
           done
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
+
+          sleep 60
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -484,6 +492,8 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
+          sleep 60
+
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
         timeout-minutes: 10
@@ -578,6 +588,8 @@ jobs:
           done
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
+
+          sleep 60
 
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
@@ -699,6 +711,8 @@ jobs:
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
 
+          sleep 60
+
       - name: Test ARC E2E
         uses: ./.github/actions/execute-assert-arc-e2e
         timeout-minutes: 10
@@ -788,6 +802,8 @@ jobs:
           done
           kubectl wait --timeout=30s --for=condition=ready pod -n arc-systems -l actions.github.com/scale-set-name=$ARC_NAME
           kubectl get pod -n arc-systems
+
+          sleep 60
 
       - name: Trigger long running jobs and wait for runners to pick them up
         uses: ./.github/actions/execute-assert-arc-e2e


### PR DESCRIPTION
Temporarily fix a bug with assignments. 

Improvements to logging and debugging:

* [`.github/actions/execute-assert-arc-e2e/action.yaml`](diffhunk://#diff-fa8c7b8dda021d469814bb2923cb93b10a55a2852b7cd3496a3176e64a7dabe3R191-R211): Added steps to gather listener and coredns logs to assist with debugging.

Enhancements to workflow reliability:

* [`.github/workflows/gha-e2e-tests.yaml`](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R106-R107): Added `sleep 60` commands in multiple places to ensure that pods are ready before proceeding with the tests. [[1]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R106-R107) [[2]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R199-R200) [[3]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R291-R292) [[4]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R392-R393) [[5]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R495-R496) [[6]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R592-R593) [[7]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R714-R715) [[8]](diffhunk://#diff-23d3f627aac61d66d142bfb86ad5f29bd8a93131e4354c1d979d43795c1e7751R806-R807)