### PR TITLE
Update CodeQL workflow for v3 (global-run-codeql.yaml)

### DIFF
--- a/.github/workflows/global-run-codeql.yaml
+++ b/.github/workflows/global-run-codeql.yaml
@@ -33,12 +33,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL Action v2 are deprecated per GitHub:
https://github.blog/changelog/2024-01-11-code-scanning-deprecation-of-codeql-action-v2/

There is also a warning in the workflow:
https://github.com/actions/actions-runner-controller/actions/runs/15925563085

This updates the CodeQL Actions from v2 to v3 for global-run-codeql.yaml