### PR TITLE
Update example GitHub URLs in values.yaml to include an example for enterprise account-level runners

### DIFF
--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -1,5 +1,5 @@
 ## githubConfigUrl is the GitHub url for where you want to configure runners
-## ex: https://github.com/myorg/myrepo or https://github.com/myorg
+## ex: https://github.com/myorg/myrepo or https://github.com/myorg or https://github.com/enterprises/myenterprise
 githubConfigUrl: ""
 
 ## githubConfigSecret is the k8s secret information to use when authenticating via the GitHub API.


### PR DESCRIPTION
The ARC Docs (such as [Choosing runner destinations](https://docs.github.com/en/enterprise-cloud@latest/actions/tutorials/actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#choosing-runner-destinations)) outlines it is possible to register runners at the enterprise account level and points back to `values.yaml`, but does not currently include an example for this.