### PR TITLE
Remove JIT config from ephemeral runner status field

### DIFF
--- a/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
+++ b/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
@@ -145,8 +145,6 @@ type EphemeralRunnerStatus struct {
 	RunnerId int `json:"runnerId,omitempty"`
 	// +optional
 	RunnerName string `json:"runnerName,omitempty"`
-	// +optional
-	RunnerJITConfig string `json:"runnerJITConfig,omitempty"`
 
 	// +optional
 	Failures map[string]metav1.Time `json:"failures,omitempty"`

--- a/charts/gha-runner-scale-set-controller/crds/actions.github.com_ephemeralrunners.yaml
+++ b/charts/gha-runner-scale-set-controller/crds/actions.github.com_ephemeralrunners.yaml
@@ -7874,8 +7874,6 @@ spec:
                   type: string
                 runnerId:
                   type: integer
-                runnerJITConfig:
-                  type: string
                 runnerName:
                   type: string
                 workflowRunId:

--- a/config/crd/bases/actions.github.com_ephemeralrunners.yaml
+++ b/config/crd/bases/actions.github.com_ephemeralrunners.yaml
@@ -7874,8 +7874,6 @@ spec:
                   type: string
                 runnerId:
                   type: integer
-                runnerJITConfig:
-                  type: string
                 runnerName:
                   type: string
                 workflowRunId:

--- a/controllers/actions.github.com/error.go
+++ b/controllers/actions.github.com/error.go
@@ -1,0 +1,12 @@
+package actionsgithubcom
+
+type controllerError string
+
+func (e controllerError) Error() string {
+	return string(e)
+}
+
+const (
+	retryableError = controllerError("retryable error")
+	fatalError     = controllerError("fatal error")
+)

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -618,7 +618,7 @@ func (b *ResourceBuilder) newEphemeralRunnerPod(ctx context.Context, runner *v1a
 		FilterLabels(labels, LabelKeyRunnerTemplateHash),
 		annotations,
 		runner.Spec,
-		runner.Status.RunnerJITConfig,
+		secret.Data,
 	)
 
 	objectMeta := metav1.ObjectMeta{
@@ -671,14 +671,17 @@ func (b *ResourceBuilder) newEphemeralRunnerPod(ctx context.Context, runner *v1a
 	return &newPod
 }
 
-func (b *ResourceBuilder) newEphemeralRunnerJitSecret(ephemeralRunner *v1alpha1.EphemeralRunner) *corev1.Secret {
+func (b *ResourceBuilder) newEphemeralRunnerJitSecret(ephemeralRunner *v1alpha1.EphemeralRunner, jitConfig *actions.RunnerScaleSetJitRunnerConfig) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ephemeralRunner.Name,
 			Namespace: ephemeralRunner.Namespace,
 		},
 		Data: map[string][]byte{
-			jitTokenKey: []byte(ephemeralRunner.Status.RunnerJITConfig),
+			jitTokenKey:  []byte(jitConfig.EncodedJITConfig),
+			"runnerName": []byte(jitConfig.Runner.Name),
+			"runnerId":   []byte(strconv.Itoa(jitConfig.Runner.Id)),
+			"scaleSetId": []byte(strconv.Itoa(jitConfig.Runner.RunnerScaleSetId)),
 		},
 	}
 }


### PR DESCRIPTION
There is no need for the JIT token to exist in ephemeral runner's status field. This change removes JIT config string from `ephemeralrunner` completely.