### PR TITLE
chore: conditionally add `OwnerReferences` during resource creation for `AutoScalingListener`

### DIFF
--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -140,6 +140,19 @@ func (b *ResourceBuilder) newAutoScalingListener(autoscalingRunnerSet *v1alpha1.
 		},
 	}
 
+	if namespace == autoscalingRunnerSet.Namespace {
+		autoscalingListener.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         autoscalingRunnerSet.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+				Kind:               autoscalingRunnerSet.GetObjectKind().GroupVersionKind().Kind,
+				UID:                autoscalingRunnerSet.GetUID(),
+				Name:               autoscalingRunnerSet.GetName(),
+				Controller:         boolPtr(true),
+				BlockOwnerDeletion: boolPtr(true),
+			},
+		}
+	}
+
 	return autoscalingListener, nil
 }
 

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -242,4 +242,19 @@ func TestOwnershipRelationships(t *testing.T) {
 	assert.Equal(t, ephemeralRunner.GetUID(), ownerRef.UID, "Owner reference UID should match EphemeralRunner UID")
 	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
 	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion, "BlockOwnerDeletion flag should be true")
+
+	// Create AutoScalingListener in AutoScalingRunnerSet namespace
+	autoscalingListener, err := b.newAutoScalingListener(&autoscalingRunnerSet, ephemeralRunnerSet, autoscalingRunnerSet.Namespace, "test:latest", nil)
+	require.NoError(t, err)
+	require.Len(t, autoscalingListener.OwnerReferences, 1, "AutoScalingListener should have exactly one owner reference")
+	ownerRef = autoscalingListener.OwnerReferences[0]
+	assert.Equal(t, autoscalingRunnerSet.GetName(), ownerRef.Name, "Owner reference name should match AutoscalingRunnerSet name")
+	assert.Equal(t, autoscalingRunnerSet.GetUID(), ownerRef.UID, "Owner reference UID should match AutoscalingRunnerSet UID")
+	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
+	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion, "BlockOwnerDeletion flag should be true")
+
+	// Create AutoScalingListener in external controller namespace
+	autoscalingListener, err = b.newAutoScalingListener(&autoscalingRunnerSet, ephemeralRunnerSet, "controller-ns", "test:latest", nil)
+	require.NoError(t, err)
+	require.Len(t, autoscalingListener.OwnerReferences, 0, "AutoScalingListener should not have any owner references")
 }


### PR DESCRIPTION
Addressing issue #4031 and building upon PR #3575

As per this [comment](https://github.com/actions/actions-runner-controller/pull/3575#issuecomment-2703191490), owner references cannot be cross-namespace. Since the default architecture for ARC is to install the runner scale sets in separate namespaces to the controllers and listeners, the owner reference for AutoScalingListeners cannot be set.

However, ARC can run in single-namespace configuration, which can be the same namespace as the runner scale sets. In this scenario, the ownerReference can be set on the AutoScalingListener.
