### PR TITLE
docs: fix repo path typo

### DIFF
--- a/docs/authenticating-to-the-github-api.md
+++ b/docs/authenticating-to-the-github-api.md
@@ -200,7 +200,7 @@ metadata:
 spec:
   template:
     spec:
-      repository: USER/REO
+      repository: USER/REPO
       serviceAccountName: my-service-account
       securityContext:
         # For Ubuntu 20.04 runner


### PR DESCRIPTION
spotted a typo: changed `USER/REO` to `USER/REPO`.
