### PR TITLE
Remove ephemeral runner when exit code != 0 and is patched with the job

### DIFF
--- a/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
+++ b/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
@@ -34,6 +34,7 @@ const EphemeralRunnerContainerName = "runner"
 // +kubebuilder:printcolumn:JSONPath=".status.jobWorkflowRef",name=JobWorkflowRef,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.workflowRunId",name=WorkflowRunId,type=number
 // +kubebuilder:printcolumn:JSONPath=".status.jobDisplayName",name=JobDisplayName,type=string
+// +kubebuilder:printcolumn:JSONPath=".status.jobId",name=JobId,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.message",name=Message,type=string
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -51,7 +52,7 @@ func (er *EphemeralRunner) IsDone() bool {
 }
 
 func (er *EphemeralRunner) HasJob() bool {
-	return er.Status.WorkflowRunId != 0
+	return len(er.Status.JobID) > 0
 }
 
 func (er *EphemeralRunner) HasContainerHookConfigured() bool {
@@ -155,6 +156,9 @@ type EphemeralRunnerStatus struct {
 
 	// +optional
 	JobRequestId int64 `json:"jobRequestId,omitempty"`
+
+	// +optional
+	JobID string `json:"jobId,omitempty"`
 
 	// +optional
 	JobRepositoryName string `json:"jobRepositoryName,omitempty"`

--- a/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
+++ b/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
@@ -51,7 +51,7 @@ func (er *EphemeralRunner) IsDone() bool {
 }
 
 func (er *EphemeralRunner) HasJob() bool {
-	return er.Status.JobRequestId != 0
+	return er.Status.WorkflowRunId != 0
 }
 
 func (er *EphemeralRunner) HasContainerHookConfigured() bool {

--- a/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
+++ b/apis/actions.github.com/v1alpha1/ephemeralrunner_types.go
@@ -50,6 +50,10 @@ func (er *EphemeralRunner) IsDone() bool {
 	return er.Status.Phase == corev1.PodSucceeded || er.Status.Phase == corev1.PodFailed
 }
 
+func (er *EphemeralRunner) HasJob() bool {
+	return er.Status.JobRequestId != 0
+}
+
 func (er *EphemeralRunner) HasContainerHookConfigured() bool {
 	for i := range er.Spec.Spec.Containers {
 		if er.Spec.Spec.Containers[i].Name != EphemeralRunnerContainerName {

--- a/charts/gha-runner-scale-set-controller/crds/actions.github.com_ephemeralrunners.yaml
+++ b/charts/gha-runner-scale-set-controller/crds/actions.github.com_ephemeralrunners.yaml
@@ -36,6 +36,9 @@ spec:
         - jsonPath: .status.jobDisplayName
           name: JobDisplayName
           type: string
+        - jsonPath: .status.jobId
+          name: JobId
+          type: string
         - jsonPath: .status.message
           name: Message
           type: string
@@ -7845,6 +7848,8 @@ spec:
                     type: string
                   type: object
                 jobDisplayName:
+                  type: string
+                jobId:
                   type: string
                 jobRepositoryName:
                   type: string

--- a/cmd/ghalistener/listener/listener.go
+++ b/cmd/ghalistener/listener/listener.go
@@ -361,7 +361,7 @@ func (l *Listener) parseMessage(ctx context.Context, msg *actions.RunnerScaleSet
 				return nil, fmt.Errorf("failed to decode job available: %w", err)
 			}
 
-			l.logger.Info("Job available message received", "jobId", jobAvailable.RunnerRequestId)
+			l.logger.Info("Job available message received", "jobId", jobAvailable.JobID)
 			parsedMsg.jobsAvailable = append(parsedMsg.jobsAvailable, &jobAvailable)
 
 		case messageTypeJobAssigned:
@@ -370,14 +370,14 @@ func (l *Listener) parseMessage(ctx context.Context, msg *actions.RunnerScaleSet
 				return nil, fmt.Errorf("failed to decode job assigned: %w", err)
 			}
 
-			l.logger.Info("Job assigned message received", "jobId", jobAssigned.RunnerRequestId)
+			l.logger.Info("Job assigned message received", "jobId", jobAssigned.JobID)
 
 		case messageTypeJobStarted:
 			var jobStarted actions.JobStarted
 			if err := json.Unmarshal(msg, &jobStarted); err != nil {
 				return nil, fmt.Errorf("could not decode job started message. %w", err)
 			}
-			l.logger.Info("Job started message received.", "RequestId", jobStarted.RunnerRequestId, "RunnerId", jobStarted.RunnerId)
+			l.logger.Info("Job started message received.", "JobID", jobStarted.JobID, "RunnerId", jobStarted.RunnerID)
 			parsedMsg.jobsStarted = append(parsedMsg.jobsStarted, &jobStarted)
 
 		case messageTypeJobCompleted:
@@ -386,7 +386,13 @@ func (l *Listener) parseMessage(ctx context.Context, msg *actions.RunnerScaleSet
 				return nil, fmt.Errorf("failed to decode job completed: %w", err)
 			}
 
-			l.logger.Info("Job completed message received.", "RequestId", jobCompleted.RunnerRequestId, "Result", jobCompleted.Result, "RunnerId", jobCompleted.RunnerId, "RunnerName", jobCompleted.RunnerName)
+			l.logger.Info(
+				"Job completed message received.",
+				"JobID", jobCompleted.JobID,
+				"Result", jobCompleted.Result,
+				"RunnerId", jobCompleted.RunnerId,
+				"RunnerName", jobCompleted.RunnerName,
+			)
 			parsedMsg.jobsCompleted = append(parsedMsg.jobsCompleted, &jobCompleted)
 
 		default:
@@ -400,7 +406,7 @@ func (l *Listener) parseMessage(ctx context.Context, msg *actions.RunnerScaleSet
 func (l *Listener) acquireAvailableJobs(ctx context.Context, jobsAvailable []*actions.JobAvailable) ([]int64, error) {
 	ids := make([]int64, 0, len(jobsAvailable))
 	for _, job := range jobsAvailable {
-		ids = append(ids, job.RunnerRequestId)
+		ids = append(ids, job.RunnerRequestID)
 	}
 
 	l.logger.Info("Acquiring jobs", "count", len(ids), "requestIds", fmt.Sprint(ids))

--- a/cmd/ghalistener/listener/listener_test.go
+++ b/cmd/ghalistener/listener/listener_test.go
@@ -627,17 +627,17 @@ func TestListener_acquireAvailableJobs(t *testing.T) {
 		availableJobs := []*actions.JobAvailable{
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 1,
+					RunnerRequestID: 1,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 2,
+					RunnerRequestID: 2,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 3,
+					RunnerRequestID: 3,
 				},
 			},
 		}
@@ -678,17 +678,17 @@ func TestListener_acquireAvailableJobs(t *testing.T) {
 		availableJobs := []*actions.JobAvailable{
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 1,
+					RunnerRequestID: 1,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 2,
+					RunnerRequestID: 2,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 3,
+					RunnerRequestID: 3,
 				},
 			},
 		}
@@ -724,17 +724,17 @@ func TestListener_acquireAvailableJobs(t *testing.T) {
 		availableJobs := []*actions.JobAvailable{
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 1,
+					RunnerRequestID: 1,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 2,
+					RunnerRequestID: 2,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 3,
+					RunnerRequestID: 3,
 				},
 			},
 		}
@@ -809,17 +809,17 @@ func TestListener_acquireAvailableJobs(t *testing.T) {
 		availableJobs := []*actions.JobAvailable{
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 1,
+					RunnerRequestID: 1,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 2,
+					RunnerRequestID: 2,
 				},
 			},
 			{
 				JobMessageBase: actions.JobMessageBase{
-					RunnerRequestId: 3,
+					RunnerRequestID: 3,
 				},
 			},
 		}
@@ -881,7 +881,7 @@ func TestListener_parseMessage(t *testing.T) {
 					JobMessageType: actions.JobMessageType{
 						MessageType: messageTypeJobAvailable,
 					},
-					RunnerRequestId: 1,
+					RunnerRequestID: 1,
 				},
 			},
 			{
@@ -890,7 +890,7 @@ func TestListener_parseMessage(t *testing.T) {
 					JobMessageType: actions.JobMessageType{
 						MessageType: messageTypeJobAvailable,
 					},
-					RunnerRequestId: 2,
+					RunnerRequestID: 2,
 				},
 			},
 		}
@@ -904,7 +904,7 @@ func TestListener_parseMessage(t *testing.T) {
 					JobMessageType: actions.JobMessageType{
 						MessageType: messageTypeJobAssigned,
 					},
-					RunnerRequestId: 3,
+					RunnerRequestID: 3,
 				},
 			},
 			{
@@ -912,7 +912,7 @@ func TestListener_parseMessage(t *testing.T) {
 					JobMessageType: actions.JobMessageType{
 						MessageType: messageTypeJobAssigned,
 					},
-					RunnerRequestId: 4,
+					RunnerRequestID: 4,
 				},
 			},
 		}
@@ -926,9 +926,9 @@ func TestListener_parseMessage(t *testing.T) {
 					JobMessageType: actions.JobMessageType{
 						MessageType: messageTypeJobStarted,
 					},
-					RunnerRequestId: 5,
+					RunnerRequestID: 5,
 				},
-				RunnerId:   2,
+				RunnerID:   2,
 				RunnerName: "runner2",
 			},
 		}
@@ -942,7 +942,7 @@ func TestListener_parseMessage(t *testing.T) {
 					JobMessageType: actions.JobMessageType{
 						MessageType: messageTypeJobCompleted,
 					},
-					RunnerRequestId: 6,
+					RunnerRequestID: 6,
 				},
 				Result:     "success",
 				RunnerId:   1,

--- a/cmd/ghalistener/listener/metrics_test.go
+++ b/cmd/ghalistener/listener/metrics_test.go
@@ -123,9 +123,9 @@ func TestHandleMessageMetrics(t *testing.T) {
 				JobMessageType: actions.JobMessageType{
 					MessageType: messageTypeJobStarted,
 				},
-				RunnerRequestId: 8,
+				RunnerRequestID: 8,
 			},
-			RunnerId:   3,
+			RunnerID:   3,
 			RunnerName: "runner3",
 		},
 	}
@@ -139,7 +139,7 @@ func TestHandleMessageMetrics(t *testing.T) {
 				JobMessageType: actions.JobMessageType{
 					MessageType: messageTypeJobCompleted,
 				},
-				RunnerRequestId: 6,
+				RunnerRequestID: 6,
 			},
 			Result:     "success",
 			RunnerId:   1,
@@ -150,7 +150,7 @@ func TestHandleMessageMetrics(t *testing.T) {
 				JobMessageType: actions.JobMessageType{
 					MessageType: messageTypeJobCompleted,
 				},
-				RunnerRequestId: 7,
+				RunnerRequestID: 7,
 			},
 			Result:     "success",
 			RunnerId:   2,

--- a/cmd/ghalistener/worker/worker.go
+++ b/cmd/ghalistener/worker/worker.go
@@ -100,10 +100,11 @@ func (w *Worker) HandleJobStarted(ctx context.Context, jobInfo *actions.JobStart
 		"runnerName", jobInfo.RunnerName,
 		"ownerName", jobInfo.OwnerName,
 		"repoName", jobInfo.RepositoryName,
+		"jobId", jobInfo.JobID,
 		"workflowRef", jobInfo.JobWorkflowRef,
-		"workflowRunId", jobInfo.WorkflowRunId,
+		"workflowRunId", jobInfo.WorkflowRunID,
 		"jobDisplayName", jobInfo.JobDisplayName,
-		"requestId", jobInfo.RunnerRequestId)
+		"requestId", jobInfo.RunnerRequestID)
 
 	original, err := json.Marshal(&v1alpha1.EphemeralRunner{})
 	if err != nil {
@@ -113,9 +114,10 @@ func (w *Worker) HandleJobStarted(ctx context.Context, jobInfo *actions.JobStart
 	patch, err := json.Marshal(
 		&v1alpha1.EphemeralRunner{
 			Status: v1alpha1.EphemeralRunnerStatus{
-				JobRequestId:      jobInfo.RunnerRequestId,
+				JobRequestId:      jobInfo.RunnerRequestID,
 				JobRepositoryName: fmt.Sprintf("%s/%s", jobInfo.OwnerName, jobInfo.RepositoryName),
-				WorkflowRunId:     jobInfo.WorkflowRunId,
+				JobID:             jobInfo.JobID,
+				WorkflowRunId:     jobInfo.WorkflowRunID,
 				JobWorkflowRef:    jobInfo.JobWorkflowRef,
 				JobDisplayName:    jobInfo.JobDisplayName,
 			},

--- a/config/crd/bases/actions.github.com_ephemeralrunners.yaml
+++ b/config/crd/bases/actions.github.com_ephemeralrunners.yaml
@@ -36,6 +36,9 @@ spec:
         - jsonPath: .status.jobDisplayName
           name: JobDisplayName
           type: string
+        - jsonPath: .status.jobId
+          name: JobId
+          type: string
         - jsonPath: .status.message
           name: Message
           type: string
@@ -7845,6 +7848,8 @@ spec:
                     type: string
                   type: object
                 jobDisplayName:
+                  type: string
+                jobId:
                   type: string
                 jobRepositoryName:
                   type: string

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -213,7 +213,7 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(Succeed(), "failed to get ephemeral runner")
 
 			// update job id to simulate job assigned
-			er.Status.JobRequestId = 1
+			er.Status.WorkflowRunId = 1
 			err := k8sClient.Status().Update(ctx, er)
 			Expect(err).To(BeNil(), "failed to update ephemeral runner status")
 
@@ -224,7 +224,7 @@ var _ = Describe("EphemeralRunner", func() {
 					if err != nil {
 						return 0, err
 					}
-					return er.Status.JobRequestId, nil
+					return er.Status.WorkflowRunId, nil
 				},
 				ephemeralRunnerTimeout,
 				ephemeralRunnerInterval,

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -213,22 +213,22 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(Succeed(), "failed to get ephemeral runner")
 
 			// update job id to simulate job assigned
-			er.Status.WorkflowRunId = 1
+			er.Status.JobID = "1"
 			err := k8sClient.Status().Update(ctx, er)
 			Expect(err).To(BeNil(), "failed to update ephemeral runner status")
 
 			er = new(v1alpha1.EphemeralRunner)
 			Eventually(
-				func() (int64, error) {
+				func() (string, error) {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, er)
 					if err != nil {
-						return 0, err
+						return "", err
 					}
-					return er.Status.WorkflowRunId, nil
+					return er.Status.JobID, nil
 				},
 				ephemeralRunnerTimeout,
 				ephemeralRunnerInterval,
-			).Should(BeEquivalentTo(int64(1)))
+			).Should(BeEquivalentTo("1"))
 
 			pod := new(corev1.Pod)
 			Eventually(func() (bool, error) {

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -176,7 +176,7 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(BeEquivalentTo(ephemeralRunner.Name))
 		})
 
-		It("It should re-create pod on failure", func() {
+		It("It should re-create pod on failure and no job assigned", func() {
 			pod := new(corev1.Pod)
 			Eventually(func() (bool, error) {
 				if err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, pod); err != nil {
@@ -200,6 +200,67 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(BeEquivalentTo(true))
 		})
 
+		It("It should delete ephemeral runner on failure and job assigned", func() {
+			er := new(v1alpha1.EphemeralRunner)
+			// Check if finalizer is added
+			Eventually(
+				func() error {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, er)
+					return err
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(Succeed(), "failed to get ephemeral runner")
+
+			// update job id to simulate job assigned
+			er.Status.JobRequestId = 1
+			err := k8sClient.Status().Update(ctx, er)
+			Expect(err).To(BeNil(), "failed to update ephemeral runner status")
+
+			er = new(v1alpha1.EphemeralRunner)
+			Eventually(
+				func() (int64, error) {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, er)
+					if err != nil {
+						return 0, err
+					}
+					return er.Status.JobRequestId, nil
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeEquivalentTo(int64(1)))
+
+			pod := new(corev1.Pod)
+			Eventually(func() (bool, error) {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, pod); err != nil {
+					return false, err
+				}
+				return true, nil
+			}).Should(BeEquivalentTo(true))
+
+			// delete pod to simulate failure
+			pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+				Name: v1alpha1.EphemeralRunnerContainerName,
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+					},
+				},
+			})
+			err = k8sClient.Status().Update(ctx, pod)
+			Expect(err).To(BeNil(), "Failed to update pod status")
+
+			er = new(v1alpha1.EphemeralRunner)
+			Eventually(
+				func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, er)
+					return kerrors.IsNotFound(err)
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeTrue(), "Ephemeral runner should eventually be deleted")
+		})
+
 		It("It should failed if a pod template is invalid", func() {
 			invalideEphemeralRunner := newExampleRunner("invalid-ephemeral-runner", autoscalingNS.Name, configSecret.Name)
 			invalideEphemeralRunner.Spec.Spec.PriorityClassName = "notexist"
@@ -208,13 +269,22 @@ var _ = Describe("EphemeralRunner", func() {
 			Expect(err).To(BeNil())
 
 			updated := new(v1alpha1.EphemeralRunner)
-			Eventually(func() (corev1.PodPhase, error) {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: invalideEphemeralRunner.Name, Namespace: invalideEphemeralRunner.Namespace}, updated)
-				if err != nil {
-					return "", nil
-				}
-				return updated.Status.Phase, nil
-			}, ephemeralRunnerTimeout, ephemeralRunnerInterval).Should(BeEquivalentTo(corev1.PodFailed))
+			Eventually(
+				func() (corev1.PodPhase, error) {
+					err := k8sClient.Get(
+						ctx,
+						client.ObjectKey{Name: invalideEphemeralRunner.Name, Namespace: invalideEphemeralRunner.Namespace},
+						updated,
+					)
+					if err != nil {
+						return "", nil
+					}
+					return updated.Status.Phase, nil
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeEquivalentTo(corev1.PodFailed))
+
 			Expect(updated.Status.Reason).Should(Equal("InvalidPod"))
 			Expect(updated.Status.Message).Should(Equal("Failed to create the pod: pods \"invalid-ephemeral-runner\" is forbidden: no PriorityClass with name notexist was found"))
 		})
@@ -775,7 +845,7 @@ var _ = Describe("EphemeralRunner", func() {
 			startManagers(GinkgoT(), mgr)
 		})
 
-		It("It should set the Phase to Succeeded", func() {
+		It("It should delete EphemeralRunner when pod exits successfully", func() {
 			ephemeralRunner := newExampleRunner("test-runner", autoscalingNS.Name, configSecret.Name)
 
 			err := k8sClient.Create(ctx, ephemeralRunner)
@@ -801,13 +871,18 @@ var _ = Describe("EphemeralRunner", func() {
 			Expect(err).To(BeNil(), "failed to update pod status")
 
 			updated := new(v1alpha1.EphemeralRunner)
-			Eventually(func() (corev1.PodPhase, error) {
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, updated)
-				if err != nil {
-					return "", nil
-				}
-				return updated.Status.Phase, nil
-			}, ephemeralRunnerTimeout, ephemeralRunnerInterval).Should(BeEquivalentTo(corev1.PodSucceeded))
+			Eventually(
+				func() bool {
+					err := k8sClient.Get(
+						ctx,
+						client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace},
+						updated,
+					)
+					return kerrors.IsNotFound(err)
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeTrue())
 		})
 	})
 

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -453,7 +453,7 @@ func (r *EphemeralRunnerSetReconciler) deleteIdleEphemeralRunners(ctx context.Co
 			continue
 		}
 
-		if !isDone && ephemeralRunner.Status.JobRequestId > 0 {
+		if !isDone && ephemeralRunner.HasJob() {
 			log.Info("Skipping ephemeral runner since it is running a job", "name", ephemeralRunner.Name, "jobRequestId", ephemeralRunner.Status.JobRequestId)
 			continue
 		}

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -454,7 +454,12 @@ func (r *EphemeralRunnerSetReconciler) deleteIdleEphemeralRunners(ctx context.Co
 		}
 
 		if !isDone && ephemeralRunner.HasJob() {
-			log.Info("Skipping ephemeral runner since it is running a job", "name", ephemeralRunner.Name, "workflowRunId", ephemeralRunner.Status.WorkflowRunId)
+			log.Info(
+				"Skipping ephemeral runner since it is running a job",
+				"name", ephemeralRunner.Name,
+				"workflowRunId", ephemeralRunner.Status.WorkflowRunId,
+				"jobId", ephemeralRunner.Status.JobID,
+			)
 			continue
 		}
 

--- a/controllers/actions.github.com/ephemeralrunnerset_controller.go
+++ b/controllers/actions.github.com/ephemeralrunnerset_controller.go
@@ -454,7 +454,7 @@ func (r *EphemeralRunnerSetReconciler) deleteIdleEphemeralRunners(ctx context.Co
 		}
 
 		if !isDone && ephemeralRunner.HasJob() {
-			log.Info("Skipping ephemeral runner since it is running a job", "name", ephemeralRunner.Name, "jobRequestId", ephemeralRunner.Status.JobRequestId)
+			log.Info("Skipping ephemeral runner since it is running a job", "name", ephemeralRunner.Name, "workflowRunId", ephemeralRunner.Status.WorkflowRunId)
 			continue
 		}
 

--- a/github/actions/types.go
+++ b/github/actions/types.go
@@ -37,7 +37,7 @@ type JobAssigned struct {
 }
 
 type JobStarted struct {
-	RunnerId   int    `json:"runnerId"`
+	RunnerID   int    `json:"runnerId"`
 	RunnerName string `json:"runnerName"`
 	JobMessageBase
 }
@@ -55,12 +55,13 @@ type JobMessageType struct {
 
 type JobMessageBase struct {
 	JobMessageType
-	RunnerRequestId    int64     `json:"runnerRequestId"`
+	RunnerRequestID    int64     `json:"runnerRequestId"`
 	RepositoryName     string    `json:"repositoryName"`
 	OwnerName          string    `json:"ownerName"`
+	JobID              string    `json:"jobId"`
 	JobWorkflowRef     string    `json:"jobWorkflowRef"`
 	JobDisplayName     string    `json:"jobDisplayName"`
-	WorkflowRunId      int64     `json:"workflowRunId"`
+	WorkflowRunID      int64     `json:"workflowRunId"`
 	EventName          string    `json:"eventName"`
 	RequestLabels      []string  `json:"requestLabels"`
 	QueueTime          time.Time `json:"queueTime"`


### PR DESCRIPTION
If the runner exits with the exit code != 0, it might have been killed by something external.

Therefore, we should delete this ephemeral runner without having to retry it since its configuration is no longer valid, and the job failed.

Regarding #4091, `0.12.1` release should fix the issue where the race condition is not checked when the runner exits with exit code 0. However, if there is pressure on the node that kills the runner, we would still retry the runner even though the credentials are no longer valid. This PR aims to fix it completely by removing the ephemeral runner IF we are certain that the job was assigned to it.

Let's explain the worst case scenario:
1. The ephemeral runner is created and started the pod.
2. The pod starts and is killed right away
3. At this point, the listener did not have time to patch the ephemeral runner just yet.
4. The ephemeral runner controller would re-create the job pod with the back-off.
5. The listener during this time should already be notified about the job assignment, and should patch the ephemeral runner.
6. The pod exits again, since the configuration is no longer valid
7. However, this time, ephemeral runner controller notices that the job was assigned to that ephemeral runner, and removes the ephemeral runner, cleaning up the slot for scaling.

Fixes #4091