### PR TITLE
Allow setting the MTU of nested Docker daemon in DinD mode

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -101,6 +101,7 @@ args:
   - dockerd
   - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
+  - --mtu={{ default 1450 (dig "dind" "mtu" 1450 .Values.containerMode) }}
 env:
   - name: DOCKER_GROUP_GID
     value: "123"

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -116,6 +116,8 @@ githubConfigSecret:
 ## empty, and configuration should be applied to the template.
 # containerMode:
 #   type: "dind"  ## type can be set to "dind", "kubernetes", or "kubernetes-novolume"
+#   dind:
+#     mtu: 1450   ## Optional, for DinD mode only.  Defaults to 1450.
 #   ## the following is required when containerMode.type=kubernetes
 #   kubernetesModeWorkVolumeClaim:
 #     accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
When running DinD it's common to need a lower MTU on the nested Docker bridge.

Use a default of 1450 as it's generally safer than not doing anything, and pretty harmless if done when not needed.