### PR TITLE
Add GitHub workflow and job metadata labels to runner pods

### DIFF
--- a/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
@@ -31,7 +31,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list", "create", "delete"]
+  verbs: ["get", "list", "create", "delete", "update", "patch"]
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["get", "create"]

--- a/charts/gha-runner-scale-set/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role.yaml
@@ -35,6 +35,8 @@ rules:
   - create
   - delete
   - get
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Problem**
Organizations using GitHub Actions with self-hosted runners on GKE cannot attribute costs to specific repositories, workflows, or jobs because runner pods lack workflow metadata labels.

**Solution**
Automatically apply workflow metadata as pod labels when jobs start, enabling cost tracking through GKE's existing cost allocation infrastructure.

Reference: https://cloud.google.com/kubernetes-engine/docs/how-to/cost-allocations

**Changes**

1. **Worker Implementation** (`cmd/ghalistener/worker/worker.go`):
   - Added `updatePodLabelsWithWorkflowMetadata()` function
   - Added `sanitizeLabelValue()` for Kubernetes label validation
   - Modified `HandleJobStarted()` to apply labels when jobs start
   - Added `WithClientset()` option for testability

2. **RBAC Permissions** (`charts/gha-runner-scale-set/templates/manager_role.yaml`):
   - Added `update` and `patch` verbs to pods rule

**Labels Applied**
- `github.com/repository`: Repository name (sanitized)
- `github.com/workflow`: Workflow reference (sanitized) 
- `github.com/job`: Job display name (sanitized)
- `github.com/job-id`: Unique job ID
- `github.com/run-id`: Workflow run ID

**Example Output**
```
labels:
  actions.github.com/organization: example-org
  actions.github.com/scale-set-name: runners-x
  actions.github.com/scale-set-namespace: arc-runners
  github.com/job: build
  github.com/job-id: 1234abcd-5678-90ef-1234-567890abcdef
  github.com/repository: example-repo
  github.com/run-id: "123456789"
  github.com/workflow: example-repo-.github-workflows-build.yaml-refs-heads-main
```

**Key Features**
- Labels applied when jobs actually start (not when pods are created)
- All values sanitized for Kubernetes compliance
- Graceful error handling - failures don't affect job execution
- Works with existing GKE cost allocation and BigQuery exports

**Testing**
- ✅ Tested in production environment
- ✅ Verified labels are correctly applied and sanitized
- ✅ Confirmed RBAC permissions work correctly

**Benefits**
- Real-time cost tracking by repository, workflow, and job
- Leverages existing GKE cost allocation infrastructure
- No performance impact (one-time label assignment)
- Automatic integration with BigQuery cost queries
- Backward compatible with no breaking changes

This enables organizations to track GitHub Actions costs at the repository, workflow, and job level using their existing GKE cost allocation setup.

disclaimer: this was developed isong Cursor AI, so it needs a proper review.