### PR TITLE
Allow extra args for docker daemon when in dind mode

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -101,6 +101,13 @@ args:
   - dockerd
   - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
+{{- /* Append extra args only if containerMode.dind.extraDockerDaemonArgs exists and is a list */ -}}
+{{- if and (kindIs "map" .Values.containerMode) (kindIs "map" (get .Values.containerMode "dind")) -}}
+  {{- $extra := (get (get .Values.containerMode "dind") "extraDockerDaemonArgs") | default (list) -}}
+  {{- range $extra }}
+  - {{ . | quote }}
+  {{- end }}
+{{- end }}
 env:
   - name: DOCKER_GROUP_GID
     value: "123"

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -116,6 +116,12 @@ githubConfigSecret:
 ## empty, and configuration should be applied to the template.
 # containerMode:
 #   type: "dind"  ## type can be set to "dind", "kubernetes", or "kubernetes-novolume"
+#   dind:
+#     ## extraDockerDaemonArgs is a list of extra arguments to pass to the docker daemon
+#     extraDockerDaemonArgs:
+#       - --registry-mirror=https://my-mirror.com
+#       - --https-proxy=http://my-proxy.com:1234
+#       - --mtu=1400
 #   ## the following is required when containerMode.type=kubernetes
 #   kubernetesModeWorkVolumeClaim:
 #     accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
Allow configuring the Docker daemon (dockerd) in `DinD` mode by introducing `containerMode.dind.extraDockerDaemonArgs`, a list of flags appended to the DinD container’s args.