### PR TITLE
docs: fix broken Grafana dashboard JSON path

### DIFF
--- a/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/README.md
+++ b/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/README.md
@@ -15,7 +15,7 @@ This sample dashboard shows how to visualize the metrics with [Grafana](https://
 
 1. Make sure to have [Grafana](https://grafana.com/docs/grafana/latest/installation/) and [Prometheus](https://prometheus.io/docs/prometheus/latest/installation/) running in your cluster.
 2. Make sure that Prometheus is properly scraping the metrics endpoints of the controller-manager and listeners.
-3. Import the [dashboard](ARC-Autoscaling-Runner-Set-Monitoring_1692627561838.json) into Grafana.
+3. Import the [dashboard](ARC-Autoscaling-Runner-Set-Monitoring.json) into Grafana.
 
 ## Required metrics
 


### PR DESCRIPTION
### Summary
Fixes an incorrect reference to the Grafana dashboard JSON file in the documentation.

### Details
The docs currently reference:
`ARC-Autoscaling-Runner-Set-Monitoring_1692627561838.json`

The actual file name in the repository is:
`ARC-Autoscaling-Runner-Set-Monitoring.json` 
https://github.com/actions/actions-runner-controller/blob/master/docs/gha-runner-scale-set-controller/samples/grafana-dashboard/ARC-Autoscaling-Runner-Set-Monitoring.json
