### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arc-update-runners-scheduled.yaml
+++ b/.github/workflows/arc-update-runners-scheduled.yaml
@@ -50,6 +50,8 @@ jobs:
   # it sets a PR name as output.
   check_pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: check_versions
     if: needs.check_versions.outputs.runner_current_version != needs.check_versions.outputs.runner_latest_version || needs.check_versions.outputs.container_hooks_current_version != needs.check_versions.outputs.container_hooks_latest_version
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/actions/actions-runner-controller/security/code-scanning/3](https://github.com/actions/actions-runner-controller/security/code-scanning/3)

To fix the issue, explicitly declare a permissions block for the `check_pr` job in `.github/workflows/arc-update-runners-scheduled.yaml`, with the minimum privileges necessary. Since this job only needs to fetch (read) repository contents (it does not push, create, or mutate resources), set the permissions to `contents: read`. 

To implement the fix:
- Insert a `permissions:` block under the `check_pr:` job (after its `runs-on:` key and before other keys).
- This change should be made in the YAML workflow file at the relevant job block (job starting at line 51).
- You only need to add the following lines:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
