### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arc-update-runners-scheduled.yaml
+++ b/.github/workflows/arc-update-runners-scheduled.yaml
@@ -2,7 +2,8 @@
 # updates files containing runner version and opens a pull request.
 name: Runner Updates Check (Scheduled Job)
 permissions:
-  contents: read
+  pull-requests: write
+  contents: write
 
 on:
   schedule:

--- a/.github/workflows/arc-update-runners-scheduled.yaml
+++ b/.github/workflows/arc-update-runners-scheduled.yaml
@@ -1,6 +1,8 @@
 # This workflows polls releases from actions/runner and in case of a new one it
 # updates files containing runner version and opens a pull request.
 name: Runner Updates Check (Scheduled Job)
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/global-run-first-interaction.yaml
+++ b/.github/workflows/global-run-first-interaction.yaml
@@ -1,5 +1,10 @@
 name: First Interaction
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
This PR is fixing a code scanning alert about missing workflow permissions.
https://github.com/actions/actions-runner-controller/security/code-scanning/1


Copilot applies the same security best practice (explicitly declaring permissions) to multiple workflow files
The two workflows just happen to be among the files that need this security fix

.github/workflows/global-run-first-interaction.yaml 
.github/workflows/arc-update-runners-scheduled.yaml