### PR TITLE
Add support for giving kubernetes mode scaleset service account additional permissions

### DIFF
--- a/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
@@ -36,21 +36,24 @@ metadata:
   finalizers:
     - actions.github.com/cleanup-protection
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "create", "delete"]
-- apiGroups: [""]
-  resources: ["pods/exec"]
-  verbs: ["get", "create"]
-- apiGroups: [""]
-  resources: ["pods/log"]
-  verbs: ["get", "list", "watch",]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch",]
 {{- if ne $containerMode.type "kubernetes-novolume" }}
-- apiGroups: ["batch"]
-  resources: ["jobs"]
-  verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "delete"]
 {{- end }}
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "delete"]
+{{- with $containerMode.kubernetesModeAdditionalRoleRules}}
+{{- toYaml . | nindent 2}}
+{{- end }}
 {{- end }}

--- a/charts/gha-runner-scale-set/tests/values_k8s_extra_role_rules.yaml
+++ b/charts/gha-runner-scale-set/tests/values_k8s_extra_role_rules.yaml
@@ -1,0 +1,30 @@
+githubConfigUrl: https://github.com/actions/actions-runner-controller
+githubConfigSecret:
+  github_token: test
+template:
+  spec:
+    containers:
+      - name: other
+        image: other-image:latest
+    volumes:
+      - name: foo
+        emptyDir: {}
+      - name: bar
+        emptyDir: {}
+      - name: work
+        hostPath:
+          path: /data
+          type: Directory
+containerMode:
+  type: kubernetes
+  kubernetesModeAdditionalRoleRule:
+    - apiGroups:
+        - apps
+      resources:
+        - deployments
+      verbs:
+        - get
+        - list
+        - create
+        - delete
+

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -124,6 +124,7 @@ githubConfigSecret:
 #     resources:
 #       requests:
 #         storage: 1Gi
+#   kubernetesModeAdditionalRoleRules: []
 #
 
 ## listenerTemplate is the PodSpec for each listener Pod


### PR DESCRIPTION
This is useful for instance to allow buildx kubernetes driver to work, of if you use a custom container hook that needs additional permissions like pod watch.

Tested locally with ct against a kind cluster.