### PR TITLE
Fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arc-release-runners.yaml
+++ b/.github/workflows/arc-release-runners.yaml
@@ -1,4 +1,6 @@
 name: Release ARC Runner Images
+permissions:
+  contents: read
 
 # Revert to https://github.com/actions-runner-controller/releases#releases
 # for details on why we use this approach


### PR DESCRIPTION
Potential fix for [https://github.com/actions/actions-runner-controller/security/code-scanning/5](https://github.com/actions/actions-runner-controller/security/code-scanning/5)

To fix the problem, add an explicit permissions block to the workflow to restrict the permissions of the `GITHUB_TOKEN` as recommended. This can be done by adding the `permissions:` key at the root of the workflow YAML (immediately after the `name:` and before `on:`), or per-job if different jobs need different scopes. In this case, the workflow does not require repository write permissions, so restricting to `contents: read` will suffice and follows best practices. The edit should be made near the top of `.github/workflows/arc-release-runners.yaml`, after the `name:` field and before the `on:` trigger.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
