### PR TITLE
Use combination of namespace, GitHub URL, and runner group when hashing the listener name

### DIFF
--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -715,11 +715,11 @@ func proxyListenerSecretName(autoscalingListener *v1alpha1.AutoscalingListener) 
 }
 
 func proxyEphemeralRunnerSetSecretName(ephemeralRunnerSet *v1alpha1.EphemeralRunnerSet) string {
-	return fmt.Sprintf("%v-%v-runner-proxy", ephemeralRunnerSet.Name, hashSuffix(
-		ephemeralRunnerSet.Namespace,
-		ephemeralRunnerSet.Annotations[AnnotationKeyGitHubRunnerGroupName],
-		ephemeralRunnerSet.GitHubConfigUrl(),
-	))
+	namespaceHash := hash.FNVHashString(ephemeralRunnerSet.Namespace)
+	if len(namespaceHash) > 8 {
+		namespaceHash = namespaceHash[:8]
+	}
+	return fmt.Sprintf("%v-%v-runner-proxy", ephemeralRunnerSet.Name, namespaceHash)
 }
 
 func rulesForListenerRole(resourceNames []string) []rbacv1.PolicyRule {

--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -690,28 +690,36 @@ func scaleSetListenerConfigName(autoscalingListener *v1alpha1.AutoscalingListene
 	return fmt.Sprintf("%s-config", autoscalingListener.Name)
 }
 
-func scaleSetListenerName(autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet) string {
-	namespaceHash := hash.FNVHashString(autoscalingRunnerSet.Namespace)
+func hashSuffix(namespace, runnerGroup, configURL string) string {
+	namespaceHash := hash.FNVHashString(namespace + "@" + runnerGroup + "@" + configURL)
 	if len(namespaceHash) > 8 {
 		namespaceHash = namespaceHash[:8]
 	}
-	return fmt.Sprintf("%v-%v-listener", autoscalingRunnerSet.Name, namespaceHash)
+	return namespaceHash
+}
+
+func scaleSetListenerName(autoscalingRunnerSet *v1alpha1.AutoscalingRunnerSet) string {
+	return fmt.Sprintf(
+		"%v-%v-listener",
+		autoscalingRunnerSet.Name,
+		hashSuffix(
+			autoscalingRunnerSet.Namespace,
+			autoscalingRunnerSet.Spec.RunnerGroup,
+			autoscalingRunnerSet.Spec.GitHubConfigUrl,
+		),
+	)
 }
 
 func proxyListenerSecretName(autoscalingListener *v1alpha1.AutoscalingListener) string {
-	namespaceHash := hash.FNVHashString(autoscalingListener.Spec.AutoscalingRunnerSetNamespace)
-	if len(namespaceHash) > 8 {
-		namespaceHash = namespaceHash[:8]
-	}
-	return fmt.Sprintf("%v-%v-listener-proxy", autoscalingListener.Spec.AutoscalingRunnerSetName, namespaceHash)
+	return autoscalingListener.Name + "-proxy"
 }
 
 func proxyEphemeralRunnerSetSecretName(ephemeralRunnerSet *v1alpha1.EphemeralRunnerSet) string {
-	namespaceHash := hash.FNVHashString(ephemeralRunnerSet.Namespace)
-	if len(namespaceHash) > 8 {
-		namespaceHash = namespaceHash[:8]
-	}
-	return fmt.Sprintf("%v-%v-runner-proxy", ephemeralRunnerSet.Name, namespaceHash)
+	return fmt.Sprintf("%v-%v-runner-proxy", ephemeralRunnerSet.Name, hashSuffix(
+		ephemeralRunnerSet.Namespace,
+		ephemeralRunnerSet.Annotations[AnnotationKeyGitHubRunnerGroupName],
+		ephemeralRunnerSet.GitHubConfigUrl(),
+	))
 }
 
 func rulesForListenerRole(resourceNames []string) []rbacv1.PolicyRule {


### PR DESCRIPTION
GitHub URL, namespace and runner group should provide a unique hash part of the name. Since all listeners go into a single namespace, if the scale set is named the same belonging to a different runner group, the collisions could occur.
This change uses combination of the namespace, GitHub URL, and the runner group along with the name should provide a unique combination especially during testing canary release in the same namespace.

Fixes #3587