### PR TITLE
Bump timeout for min runners workflow to 30s

### DIFF
--- a/.github/workflows/gha-e2e-tests.yaml
+++ b/.github/workflows/gha-e2e-tests.yaml
@@ -984,7 +984,7 @@ jobs:
               echo "5 pods are up!"
               break
             fi
-            if [[ "$count" -ge 12 ]]; then
+            if [[ "$count" -ge 30 ]]; then
               echo "Timeout waiting for 5 pods to be created"
               exit 1
             fi


### PR DESCRIPTION
Workflow started failing due to a timeout. Bump this parameter to 30s to reduce false test failures