### PR TITLE
feat: ability to override the image of dind initContainer

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -96,7 +96,13 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+{{ $image := "docker:dind"}}
+{{- range $i, $val := .Values.template.spec.initContainers }}
+{{- if and (eq $val.name "dind") (not (empty $val.image)) }}
+{{- $image = $val.image }}
+{{- end }}
+{{- end }}
+image: {{ $image }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock


### PR DESCRIPTION
This PR proposes a fix for #3216 : Override the `docker:dind` image. 

This will allow a consumer to set the following to update the image used for `docker:dind`:
```yaml
template:
  spec:
    initContainers:
      - name: dind
        image: my-private-registry:5000/docker:dind
```

If nothing is set or the `image` key is not included, the value will still default to `docker:dind` but will now provide a way to override the image for everyone with issues pulling from DockerHub.
