### PR TITLE
Re-schedule if the failed reason starts with `OutOf`

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -316,26 +316,26 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		switch {
 		case pod.Status.Reason == "Evicted":
 			log.Info("Pod evicted; Deleting ephemeral runner or pod",
-				"PodPhase", pod.Status.Phase,
-				"PodReason", pod.Status.Reason,
-				"PodMessage", pod.Status.Message,
+				"podPhase", pod.Status.Phase,
+				"podReason", pod.Status.Reason,
+				"podMessage", pod.Status.Message,
 			)
 
 			return ctrl.Result{}, r.deleteEphemeralRunnerOrPod(ctx, ephemeralRunner, pod, log)
 
 		case strings.HasPrefix(pod.Status.Reason, "OutOf"): // most likely a transient issue.
 			log.Info("Pod set the termination phase due to resource constraints, but container state is not terminated. Deleting ephemeral runner or pod",
-				"PodPhase", pod.Status.Phase,
-				"PodReason", pod.Status.Reason,
-				"PodMessage", pod.Status.Message,
+				"podPhase", pod.Status.Phase,
+				"podReason", pod.Status.Reason,
+				"podMessage", pod.Status.Message,
 			)
 			return ctrl.Result{}, r.deleteEphemeralRunnerOrPod(ctx, ephemeralRunner, pod, log)
 
 		default:
 			log.Info("Pod is in failed phase; updating ephemeral runner status",
-				"PodPhase", pod.Status.Phase,
-				"PodReason", pod.Status.Reason,
-				"PodMessage", pod.Status.Message,
+				"podPhase", pod.Status.Phase,
+				"podReason", pod.Status.Reason,
+				"podMessage", pod.Status.Message,
 			)
 			if err := r.updateRunStatusFromPod(ctx, ephemeralRunner, pod, log); err != nil {
 				log.Info("Failed to update ephemeral runner status. Requeue to not miss this event")
@@ -349,7 +349,8 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		log.Info("Waiting for runner container status to be available")
 		return ctrl.Result{}, nil
 
-	case cs.State.Terminated == nil: // container is not terminated and pod phase is not faile< so runner is still running
+	case cs.State.Terminated == nil: // container is not terminated and pod phase is not failed, so runner is still running
+		log.Info("Runner container is still running; updating ephemeral runner status")
 		if err := r.updateRunStatusFromPod(ctx, ephemeralRunner, pod, log); err != nil {
 			log.Info("Failed to update ephemeral runner status. Requeue to not miss this event")
 			return ctrl.Result{}, err

--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -324,7 +324,7 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, r.deleteEphemeralRunnerOrPod(ctx, ephemeralRunner, pod, log)
 
 		case strings.HasPrefix(pod.Status.Reason, "OutOf"): // most likely a transient issue.
-			log.Info("Pod set the termination phase due to resource constraints, but container state is not terminated. Deleting ephemeral runner or pod",
+			log.Info("Pod failed with reason starting with OutOf. Deleting ephemeral runner or pod",
 				"podPhase", pod.Status.Phase,
 				"podReason", pod.Status.Reason,
 				"podMessage", pod.Status.Message,

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -745,6 +745,52 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(BeEquivalentTo(true))
 		})
 
+		It("It should re-create pod on OutOfsomething", func() {
+			pod := new(corev1.Pod)
+			Eventually(
+				func() (bool, error) {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, pod)
+					if err != nil {
+						return false, err
+					}
+					return true, nil
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeEquivalentTo(true))
+
+			pod.Status.Phase = corev1.PodFailed
+			pod.Status.Reason = "OutOfpods"
+			pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+				Name:  v1alpha1.EphemeralRunnerContainerName,
+				State: corev1.ContainerState{},
+			})
+			err := k8sClient.Status().Update(ctx, pod)
+			Expect(err).To(BeNil(), "failed to patch pod status")
+
+			updated := new(v1alpha1.EphemeralRunner)
+			Eventually(func() (bool, error) {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, updated)
+				if err != nil {
+					return false, err
+				}
+				return len(updated.Status.Failures) == 1, nil
+			}, ephemeralRunnerTimeout, ephemeralRunnerInterval).Should(BeEquivalentTo(true))
+
+			// should re-create after failure
+			Eventually(
+				func() (bool, error) {
+					pod := new(corev1.Pod)
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: ephemeralRunner.Name, Namespace: ephemeralRunner.Namespace}, pod); err != nil {
+						return false, err
+					}
+					return true, nil
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeEquivalentTo(true))
+		})
+
 		It("It should not set the phase to succeeded without pod termination status", func() {
 			pod := new(corev1.Pod)
 			Eventually(

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -745,7 +745,7 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(BeEquivalentTo(true))
 		})
 
-		It("It should re-create pod on OutOfsomething", func() {
+		It("It should re-create pod on reason starting with OutOf", func() {
 			pod := new(corev1.Pod)
 			Eventually(
 				func() (bool, error) {


### PR DESCRIPTION
Retry on `OutOf...` These issues are likely transient, so we should re-schedule the pod.

Fixes #4168