### PR TITLE
Potential fix for code scanning alert no. 7: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/controllers/actions.summerwind.net/multi_githubclient.go
+++ b/controllers/actions.summerwind.net/multi_githubclient.go
@@ -2,7 +2,7 @@ package actionssummerwindnet
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -176,7 +176,7 @@ func (c *MultiGitHubClient) initClientForSecret(secret *corev1.Secret, dependent
 
 	sort.SliceStable(ks, func(i, j int) bool { return ks[i] < ks[j] })
 
-	hash := sha1.New()
+	hash := sha256.New()
 	for _, k := range ks {
 		hash.Write(secret.Data[k])
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/actions/actions-runner-controller/security/code-scanning/7](https://github.com/actions/actions-runner-controller/security/code-scanning/7)

In general, to fix this type of issue you should replace weak hash functions (like MD5 or SHA‑1) with strong modern hashes. For hashing arbitrary secret data where computational expense is not required (this is not password hashing), a SHA‑2 family hash (such as SHA‑256) is appropriate. You only need to change the hash function used and its import; the logic of how the hash is used (as a cache key / change detector) can remain intact.

For this specific file, the best fix with minimal functional change is:

- Replace the SHA‑1 dependency with SHA‑256:
  - Remove `crypto/sha1` from the imports.
  - Add `crypto/sha256` to the imports.
- Change the hash initialization:
  - Replace `sha1.New()` with `sha256.New()`.
- Leave the rest of the logic unchanged:
  - The hash is still computed over all secret data entries (sorted by key).
  - It is still hex‑encoded and stored in `cliRef.hash`.
  - This will cause a one‑time cache miss and client recreation on upgrade (because the hash value changes), which is acceptable and does not break external behavior.

All changes are confined to `controllers/actions.summerwind.net/multi_githubclient.go` in the shown region: the import block and the initialization of `hash` in `initClientForSecret`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
