### PR TITLE
Fix `AcivityId` typo in error strings

### DIFF
--- a/github/actions/errors.go
+++ b/github/actions/errors.go
@@ -36,7 +36,7 @@ type ActionsError struct {
 }
 
 func (e *ActionsError) Error() string {
-	return fmt.Sprintf("actions error: StatusCode %d, AcivityId %q: %v", e.StatusCode, e.ActivityID, e.Err)
+	return fmt.Sprintf("actions error: StatusCode %d, ActivityId %q: %v", e.StatusCode, e.ActivityID, e.Err)
 }
 
 func (e *ActionsError) Unwrap() error {
@@ -112,7 +112,7 @@ type MessageQueueTokenExpiredError struct {
 }
 
 func (e *MessageQueueTokenExpiredError) Error() string {
-	return fmt.Sprintf("MessageQueueTokenExpiredError: AcivityId %q, StatusCode %d: %s", e.activityID, e.statusCode, e.msg)
+	return fmt.Sprintf("MessageQueueTokenExpiredError: ActivityId %q, StatusCode %d: %s", e.activityID, e.statusCode, e.msg)
 }
 
 type HttpClientSideError struct {

--- a/github/actions/errors_test.go
+++ b/github/actions/errors_test.go
@@ -22,7 +22,7 @@ func TestActionsError(t *testing.T) {
 
 		s := err.Error()
 		assert.Contains(t, s, "StatusCode 404")
-		assert.Contains(t, s, "AcivityId \"activity-id\"")
+		assert.Contains(t, s, "ActivityId \"activity-id\"")
 		assert.Contains(t, s, "example error description")
 	})
 


### PR DESCRIPTION
## What?

- [x] Fix typo in error strings
- [x] Update tests

## Why?

Noticed this whilst looking at the logs for a different issue in our cluster and ended up going down a rabbit hole investigating if something was comparing "AcivityId" to "ActivityId" and perhaps that was the error.

Turned out to just be an error string with a typo in, figured I'd update them to stop someone else going down the same rabbit hole in future.