### PR TITLE
feat(chart): make DinD sidecar image configurable via values

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -110,7 +110,7 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+image: {{ .Values.containerMode.dindImage | default "docker:dind" }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -999,6 +999,39 @@ func TestTemplateRenderedAutoScalingRunnerSet_EnableDinD(t *testing.T) {
 	assert.NotNil(t, ars.Spec.Template.Spec.Volumes[2].EmptyDir, "Volume work should be an emptyDir")
 }
 
+func TestTemplateRenderedAutoScalingRunnerSet_EnableDinD_CustomImage(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"containerMode.type":                 "dind",
+			"containerMode.dindImage":            "my-registry/docker:dind-custom",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var ars v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &ars)
+
+	assert.Len(t, ars.Spec.Template.Spec.InitContainers, 2, "Template.Spec should have 2 init containers")
+	assert.Equal(t, "dind", ars.Spec.Template.Spec.InitContainers[1].Name)
+	assert.Equal(t, "my-registry/docker:dind-custom", ars.Spec.Template.Spec.InitContainers[1].Image, "DinD container should use the custom image")
+}
+
 func TestTemplateRenderedAutoScalingRunnerSet_EnableKubernetesMode(t *testing.T) {
 	t.Parallel()
 

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -114,14 +114,16 @@ githubConfigSecret:
 ## for dind and kubernetes mode. Template will be modified as documented under the
 ## template object.
 ##
-## If any customization is required for dind or kubernetes mode, containerMode should remain
-## empty, and configuration should be applied to the template.
+## For simple customizations like overriding the DinD image, use the dindImage field below.
+## For deeper customization of dind or kubernetes mode (e.g., adding extra env vars,
+## volume mounts, or security contexts), containerMode should remain empty, and
+## configuration should be applied to the template.
 # containerMode:
 #   type: "dind"  ## type can be set to "dind", "kubernetes", or "kubernetes-novolume"
 #   ## Optional: override the default docker:dind image used for the DinD sidecar container.
 #   ## This is useful for using a custom image with pre-configured daemon.json
 #   ## (e.g., registry mirrors, insecure registries) or other customizations.
-#   # dindImage: "docker:dind"
+#   dindImage: "docker:dind"
 #   ## the following is required when containerMode.type=kubernetes
 #   kubernetesModeWorkVolumeClaim:
 #     accessModes: ["ReadWriteOnce"]

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -118,6 +118,10 @@ githubConfigSecret:
 ## empty, and configuration should be applied to the template.
 # containerMode:
 #   type: "dind"  ## type can be set to "dind", "kubernetes", or "kubernetes-novolume"
+#   ## Optional: override the default docker:dind image used for the DinD sidecar container.
+#   ## This is useful for using a custom image with pre-configured daemon.json
+#   ## (e.g., registry mirrors, insecure registries) or other customizations.
+#   # dindImage: "docker:dind"
 #   ## the following is required when containerMode.type=kubernetes
 #   kubernetesModeWorkVolumeClaim:
 #     accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
## Summary

- Add `containerMode.dindImage` value to `gha-runner-scale-set` chart to allow overriding the hardcoded `docker:dind` image in the DinD sidecar
- Defaults to `docker:dind` — fully backward compatible, no behavior change for existing users

## Motivation

`containerMode.type: dind` currently hardcodes `docker:dind` with no way to override it. Users who need a custom DinD image (e.g., with pre-configured `daemon.json` for registry mirrors or insecure registries) are forced to abandon `containerMode` entirely and manually reimplement the full DinD pod spec.

The experimental chart already supports this via `runner.dind.container.image`. This PR backports the same capability to the stable chart with a minimal, non-breaking change.

## Changes

- **`_helpers.tpl`**: Change `image: docker:dind` to `image: {{ .Values.containerMode.dindImage | default "docker:dind" }}`
- **`values.yaml`**: Add commented-out `dindImage` option under `containerMode` with documentation

## Test plan

- [ ] `helm template` with `containerMode.type=dind` and **no** `dindImage` → renders `image: docker:dind` (backward compat)
- [ ] `helm template` with `containerMode.type=dind` and `dindImage: custom/dind:v1` → renders `image: custom/dind:v1`
- [ ] Existing unit tests pass

Closes #4416

Related: #3709, #3120, #2765, #3439, #3547