### PR TITLE
Prepare 0.14.1 release

### DIFF
--- a/charts/gha-runner-scale-set-controller-experimental/Chart.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.14.0"
+version: "0.14.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/gha-runner-scale-set-controller/Chart.yaml
+++ b/charts/gha-runner-scale-set-controller/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/gha-runner-scale-set-experimental/Chart.yaml
+++ b/charts/gha-runner-scale-set-experimental/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.14.0"
+version: "0.14.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/charts/gha-runner-scale-set/Chart.yaml
+++ b/charts/gha-runner-scale-set/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 
 home: https://github.com/actions/actions-runner-controller
 

--- a/docs/gha-runner-scale-set-controller/README.md
+++ b/docs/gha-runner-scale-set-controller/README.md
@@ -43,6 +43,12 @@ You can follow [this troubleshooting guide](https://docs.github.com/en/actions/h
 
 ## Changelog
 
+### 0.14.1
+
+1. Fix null field for resource metadata fields in experimental chart [#4419](https://github.com/actions/actions-runner-controller/pull/4419)
+1. Updates: runner to v2.333.1 [#4427](https://github.com/actions/actions-runner-controller/pull/4427)
+1. Bump actions/scaleset to [v0.3.0](https://github.com/actions/scaleset/releases/tag/v0.3.0) [#4447](https://github.com/actions/actions-runner-controller/pull/4447)
+
 ### 0.14.0
 
 1. Fix ActivityId typo in error strings [#4359](https://github.com/actions/actions-runner-controller/pull/4359)


### PR DESCRIPTION
### Changes

1. Fix null field for resource metadata fields in experimental chart [#4419](https://github.com/actions/actions-runner-controller/pull/4419)
1. Updates: runner to v2.333.1 [#4427](https://github.com/actions/actions-runner-controller/pull/4427)
1. Bump actions/scaleset to [v0.3.0](https://github.com/actions/scaleset/releases/tag/v0.3.0) [#4447](https://github.com/actions/actions-runner-controller/pull/4447)