### PR TITLE
 Add a flag for enabling pprof on the controller manager

### DIFF
--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -102,12 +102,12 @@ spec:
         ports:
         {{- end }}
         {{- with .Values.metrics }}
-        - containerPort: {{regexReplaceAll ":([0-9]+)" .controllerManagerAddr "${1}"}}
+        - containerPort: {{ required "Values.metrics.controllerManagerAddr must end with a numeric port" (regexFind "[0-9]+$" .controllerManagerAddr) }}
           protocol: TCP
           name: metrics
         {{- end }}
         {{- with .Values.pprof }}
-        - containerPort: {{regexReplaceAll ":([0-9]+)" .addr "${1}"}}
+        - containerPort: {{ required "Values.pprof.addr must end with a numeric port" (regexFind "[0-9]+$" .addr) }}
           protocol: TCP
           name: pprof
         {{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -84,8 +84,8 @@ spec:
         - "--listener-metrics-endpoint="
         - "--metrics-addr=0"
         {{- end }}
-        {{- with .Values.pprof }}
-        - "--pprof-addr={{ .addr }}"
+        {{- if .Values.pprof.addr }}
+        - "--pprof-addr={{ .Values.pprof.addr }}"
         {{- end }}
         {{- range .Values.flags.excludeLabelPropagationPrefixes }}
         - "--exclude-label-propagation-prefix={{ . }}"
@@ -98,7 +98,7 @@ spec:
         {{- end }}
         command:
         - "/manager"
-        {{- if or .Values.metrics .Values.pprof }}
+        {{- if or .Values.metrics .Values.pprof.addr }}
         ports:
         {{- end }}
         {{- with .Values.metrics }}
@@ -106,8 +106,8 @@ spec:
           protocol: TCP
           name: metrics
         {{- end }}
-        {{- with .Values.pprof }}
-        - containerPort: {{ required "Values.pprof.addr must end with a numeric port" (regexFind "[0-9]+$" .addr) }}
+        {{- if .Values.pprof.addr }}
+        - containerPort: {{ required "Values.pprof.addr must end with a numeric port" (regexFind "[0-9]+$" .Values.pprof.addr) }}
           protocol: TCP
           name: pprof
         {{- end }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
         - "--listener-metrics-endpoint="
         - "--metrics-addr=0"
         {{- end }}
+        {{- with .Values.pprof }}
+        - "--pprof-addr={{ .addr }}"
+        {{- end }}
         {{- range .Values.flags.excludeLabelPropagationPrefixes }}
         - "--exclude-label-propagation-prefix={{ . }}"
         {{- end }}
@@ -95,11 +98,18 @@ spec:
         {{- end }}
         command:
         - "/manager"
-        {{- with .Values.metrics }}
+        {{- if or .Values.metrics .Values.pprof }}
         ports:
+        {{- end }}
+        {{- with .Values.metrics }}
         - containerPort: {{regexReplaceAll ":([0-9]+)" .controllerManagerAddr "${1}"}}
           protocol: TCP
           name: metrics
+        {{- end }}
+        {{- with .Values.pprof }}
+        - containerPort: {{regexReplaceAll ":([0-9]+)" .addr "${1}"}}
+          protocol: TCP
+          name: pprof
         {{- end }}
         env:
         - name: CONTROLLER_MANAGER_CONTAINER_IMAGE

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -94,8 +94,8 @@ priorityClassName: ""
 #   listenerAddr: ":8080"
 #   listenerEndpoint: "/metrics"
 
-## To enable pprof, uncomment the following lines.
-# pprof:
+## To enable pprof, uncomment the addr field below.
+pprof: {}
 #   addr: ":6060"
 
 flags:

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -94,6 +94,10 @@ priorityClassName: ""
 #   listenerAddr: ":8080"
 #   listenerEndpoint: "/metrics"
 
+## To enable pprof, uncomment the following lines.
+# pprof:
+#   addr: ":6060"
+
 flags:
   ## Log level can be set here with one of the following values: "debug", "info", "warn", "error".
   ## Defaults to "debug".

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func main() {
 		listenerMetricsEndpoint string
 
 		metricsAddr              string
+		pprofAddr                string
 		autoScalingRunnerSetOnly bool
 		enableLeaderElection     bool
 		disableAdmissionWebhook  bool
@@ -121,6 +122,7 @@ func main() {
 	flag.StringVar(&listenerMetricsAddr, "listener-metrics-addr", ":8080", "The address applied to AutoscalingListener metrics server")
 	flag.StringVar(&listenerMetricsEndpoint, "listener-metrics-endpoint", "/metrics", "The AutoscalingListener metrics server endpoint from which the metrics are collected")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-addr", "", "The address the pprof endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&leaderElectionID, "leader-election-id", "actions-runner-controller", "Controller id for leader election.")
@@ -239,6 +241,7 @@ func main() {
 			SyncPeriod:        &syncPeriod,
 			DefaultNamespaces: defaultNamespaces,
 		},
+		PprofBindAddress: pprofAddr,
 		WebhookServer:    webhookServer,
 		LeaderElection:   enableLeaderElection,
 		LeaderElectionID: leaderElectionID,


### PR DESCRIPTION
cf. https://github.com/mercari/actions-runner-controller/pull/3

## What

Add a `--pprof-addr` flag to the controller manager to expose Go's built-in pprof endpoint.

When the flag is set (e.g. `--pprof-addr=:6060`), the controller-runtime manager starts a pprof HTTP server on the specified address. When the flag is omitted or empty, pprof remains disabled (no behavior change).

The Helm chart is also updated to support configuring this via `values.yaml`.

## Why

When operating ARC at scale, profiling the controller is essential for diagnosing memory leaks, goroutine issues, and CPU bottlenecks. controller-runtime already supports `PprofBindAddress` in its manager options, but ARC does not expose it as a flag, so there is currently no way to enable pprof without modifying the source code.