### PR TITLE
Fix orphan no-permission ServiceAccount in kubernetes-novolume mode

### DIFF
--- a/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
@@ -1,6 +1,6 @@
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.noPermissionServiceAccount) }}
 {{- $containerMode := .Values.containerMode }}
-{{- if and (ne $containerMode.type "kubernetes") (not .Values.template.spec.serviceAccountName) }}
+{{- if and (ne $containerMode.type "kubernetes") (ne $containerMode.type "kubernetes-novolume") (not .Values.template.spec.serviceAccountName) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -335,6 +335,46 @@ func TestTemplateRenderedSetServiceAccountToKubeNoVolumeMode(t *testing.T) {
 	assert.Equal(t, expectedServiceAccountName, ars.Annotations[actionsgithubcom.AnnotationKeyKubernetesModeServiceAccountName])
 }
 
+func TestTemplateRenderedNoPermissionServiceAccountNotRenderedInKubernetesModes(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []string{"kubernetes", "kubernetes-novolume"} {
+		t.Run("containerMode "+mode, func(t *testing.T) {
+			helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+			require.NoError(t, err)
+
+			releaseName := "test-runners"
+			namespaceName := "test-" + strings.ToLower(random.UniqueId())
+
+			options := &helm.Options{
+				Logger: logger.Discard,
+				SetValues: map[string]string{
+					"githubConfigUrl":                    "https://github.com/actions",
+					"githubConfigSecret.github_token":    "gh_token12345",
+					"controllerServiceAccount.name":      "arc",
+					"controllerServiceAccount.namespace": "arc-system",
+					"containerMode.type":                 mode,
+				},
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+			}
+
+			_, err = helm.RenderTemplateE(
+				t,
+				options,
+				helmChartPath,
+				releaseName,
+				[]string{"templates/no_permission_serviceaccount.yaml"},
+			)
+			assert.ErrorContains(
+				t,
+				err,
+				"could not find template templates/no_permission_serviceaccount.yaml in chart",
+				"no permission service account should not be rendered in "+mode+" mode",
+			)
+		})
+	}
+}
+
 func TestTemplateRenderedUserProvideSetServiceAccount(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #4454

When `containerMode.type` is `kubernetes-novolume`, the chart renders a `<release>-gha-rs-no-permission` ServiceAccount that the runner pod never uses (it uses the `kube-mode` SA instead). The SA is created with a `actions.github.com/cleanup-protection` finalizer, but the `AutoscalingRunnerSet` has no `cleanup-no-permission-service-account-name` annotation for this mode, so `autoscalingRunnerSetFinalizerDependencyCleaner.removeNoPermissionServiceAccountFinalizer` skips it on teardown. The SA becomes an orphan that blocks `helm uninstall` / Argo CD app deletion until someone manually strips the finalizer.

## Fix

Align the creation condition with where the SA is actually used and tracked:

```diff
-{{- if and (ne $containerMode.type "kubernetes") (not .Values.template.spec.serviceAccountName) }}
+{{- if and (ne $containerMode.type "kubernetes") (ne $containerMode.type "kubernetes-novolume") (not .Values.template.spec.serviceAccountName) }}
```

## Tests

Added a table-driven test that renders the chart in both `kubernetes` and `kubernetes-novolume` modes and asserts `templates/no_permission_serviceaccount.yaml` produces no output.
