### PR TITLE
Fix listener deadlock on values-only AutoscalingRunnerSet updates with minRunners > 0

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller.go
@@ -315,7 +315,14 @@ func (r *AutoscalingRunnerSetReconciler) Reconcile(ctx context.Context, req ctrl
 
 	// Make sure the AutoscalingListener is up and running in the controller namespace
 	if !listenerFound {
-		if r.drainingJobs(&latestRunnerSet.Status) {
+		// Only block listener creation if the runner spec has changed and old-spec
+		// runners still need to drain. When only listener values changed (e.g.,
+		// minRunners, maxRunners), the existing runners are valid and the listener
+		// should be recreated immediately. Without this guard, minRunners idle
+		// runners would block listener recreation indefinitely (deadlock).
+		// See: https://github.com/actions/actions-runner-controller/issues/4432
+		runnerSpecOutdated := latestRunnerSet.Annotations[annotationKeyRunnerSpecHash] != autoscalingRunnerSet.RunnerSetSpecHash()
+		if runnerSpecOutdated && r.drainingJobs(&latestRunnerSet.Status) {
 			log.Info("Creating a new AutoscalingListener is waiting for the running and pending runners to finish. Waiting for the running and pending runners to finish:", "running", latestRunnerSet.Status.RunningEphemeralRunners, "pending", latestRunnerSet.Status.PendingEphemeralRunners)
 			return ctrl.Result{}, nil
 		}

--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -618,6 +618,85 @@ var _ = Describe("Test AutoScalingRunnerSet controller", Ordered, func() {
 				autoscalingRunnerSetTestInterval,
 			).ShouldNot(Succeed(), "Listener should not be recreated")
 		})
+
+		It("Should recreate the listener immediately when only values change (not runner spec) even with running runners. Regression test for #4432.", func() {
+			// Wait for initial setup to complete with default (immediate) strategy
+			listener := new(v1alpha1.AutoscalingListener)
+			Eventually(
+				func() error {
+					return k8sClient.Get(ctx, client.ObjectKey{Name: scaleSetListenerName(autoscalingRunnerSet), Namespace: autoscalingRunnerSet.Namespace}, listener)
+				},
+				autoscalingRunnerSetTestTimeout,
+				autoscalingRunnerSetTestInterval,
+			).Should(Succeed(), "Listener should be created")
+
+			Eventually(
+				func() (int, error) {
+					runnerSetList := new(v1alpha1.EphemeralRunnerSetList)
+					err := k8sClient.List(ctx, runnerSetList, client.InNamespace(autoscalingRunnerSet.Namespace))
+					if err != nil {
+						return 0, err
+					}
+					return len(runnerSetList.Items), nil
+				},
+				autoscalingRunnerSetTestTimeout,
+				autoscalingRunnerSetTestInterval,
+			).Should(BeEquivalentTo(1), "Only one EphemeralRunnerSet should be created")
+
+			// Now switch to eventual strategy (simulates real-world config)
+			controller.UpdateStrategy = UpdateStrategyEventual
+
+			runnerSetList := new(v1alpha1.EphemeralRunnerSetList)
+			err := k8sClient.List(ctx, runnerSetList, client.InNamespace(autoscalingRunnerSet.Namespace))
+			Expect(err).NotTo(HaveOccurred(), "failed to list EphemeralRunnerSet")
+
+			// Emulate minRunners idle runners (running but no active jobs)
+			runnerSet := runnerSetList.Items[0]
+			activeRunnerSet := runnerSet.DeepCopy()
+			activeRunnerSet.Status.CurrentReplicas = 2
+			activeRunnerSet.Status.RunningEphemeralRunners = 2
+			activeRunnerSet.Status.PendingEphemeralRunners = 0
+
+			err = k8sClient.Status().Patch(ctx, activeRunnerSet, client.MergeFrom(&runnerSet))
+			Expect(err).NotTo(HaveOccurred(), "Failed to patch runner set status")
+
+			// Patch ONLY the values hash (e.g., maxRunners changed) without changing the runner spec
+			patched := autoscalingRunnerSet.DeepCopy()
+			if patched.Annotations == nil {
+				patched.Annotations = make(map[string]string)
+			}
+			patched.Annotations[annotationKeyValuesHash] = "changed-values-hash"
+			err = k8sClient.Patch(ctx, patched, client.MergeFrom(autoscalingRunnerSet))
+			Expect(err).NotTo(HaveOccurred(), "failed to patch AutoScalingRunnerSet")
+			autoscalingRunnerSet = patched.DeepCopy()
+
+			// The listener should be deleted (values hash changed)
+			Eventually(
+				func() error {
+					return k8sClient.Get(ctx, client.ObjectKey{Name: scaleSetListenerName(autoscalingRunnerSet), Namespace: autoscalingRunnerSet.Namespace}, listener)
+				},
+				autoscalingRunnerSetTestTimeout,
+				autoscalingRunnerSetTestInterval,
+			).ShouldNot(Succeed(), "Old listener should be deleted")
+
+			// The listener SHOULD be recreated even though there are running runners,
+			// because the runner spec hasn't changed — only values changed.
+			// Before the fix for #4432, this would deadlock.
+			Eventually(
+				func() error {
+					return k8sClient.Get(ctx, client.ObjectKey{Name: scaleSetListenerName(autoscalingRunnerSet), Namespace: autoscalingRunnerSet.Namespace}, listener)
+				},
+				autoscalingRunnerSetTestTimeout,
+				autoscalingRunnerSetTestInterval,
+			).Should(Succeed(), "Listener should be recreated despite running minRunners idle runners")
+
+			// The EphemeralRunnerSet should NOT be recreated (runner spec unchanged)
+			currentRunnerSetList := new(v1alpha1.EphemeralRunnerSetList)
+			err = k8sClient.List(ctx, currentRunnerSetList, client.InNamespace(autoscalingRunnerSet.Namespace))
+			Expect(err).NotTo(HaveOccurred(), "failed to list EphemeralRunnerSet")
+			Expect(len(currentRunnerSetList.Items)).To(BeEquivalentTo(1), "EphemeralRunnerSet should not be recreated")
+			Expect(currentRunnerSetList.Items[0].Name).To(Equal(activeRunnerSet.Name), "Should be the same EphemeralRunnerSet")
+		})
 	})
 
 	It("Should update Status on EphemeralRunnerSet status Update", func() {


### PR DESCRIPTION
  Fixes #4432 (continuation of #4200, which was partially addressed by #4289).

  ## The bug

  When an `AutoscalingRunnerSet` spec is updated (e.g. via `helm upgrade`) and `minRunners > 0`, the controller can deadlock and stop picking up new jobs indefinitely.

  Reproduction is trivial:
  1. Deploy `gha-runner-scale-set` at 0.13.x / 0.14.x with `minRunners: 2, maxRunners: N`, `updateStrategy: eventual`.
  2. Wait for the listener and the 2 idle min-runners to come up.
  3. `helm upgrade` changing any listener value that does **not** change the runner pod spec (e.g. `maxRunners`).
  4. The controller deletes the out-of-date listener and then never recreates it.

  Controller logs get stuck on:
  AutoscalingListener does not exist.
  Creating a new AutoscalingListener is waiting for the running and pending runners to finish.
  {"running": 2, "pending": 0}

  The 2 "running" runners are the idle min-runners pool — they will never drain on their own, so the deadlock is permanent. Jobs queued in GitHub sit in `queued` state forever.

  ## Root cause

  `autoscalingrunnerset_controller.go` has two `drainingJobs()` gates:

  - **Line 287–303 (`RunnerSetSpecHash` mismatch path):** correctly drains and recreates the `EphemeralRunnerSet` when the runner pod spec has changed. After scale-to-zero and re-creation, the new ERS starts with `Replicas: 0`, so drainingJobs returns `false` and the listener is created normally.
  - **Line 317–321 (listener-missing path):** called on every reconciliation when the listener doesn't exist. It blocks listener creation whenever there are any running or pending runners on the **latest** ERS.

  By the time execution reaches line 317, the runner spec hash always matches the latest ERS (the mismatch branch above returns earlier). So the only runners that can ever trigger the line-318 gate are valid, current-spec runners — which, for `minRunners > 0`, includes the idle pool that exists by design. The gate blocks forever for no useful reason.

  ## The fix

  Scope the drain check at the listener-creation gate to cases where the runner spec is actually outdated:

  ```go
  runnerSpecOutdated := latestRunnerSet.Annotations[annotationKeyRunnerSpecHash] != autoscalingRunnerSet.RunnerSetSpecHash()
  if runnerSpecOutdated && r.drainingJobs(&latestRunnerSet.Status) {
      // block and wait
  }
```

  In practice, runnerSpecOutdated is never true at this point (the earlier branch handles it), so this is effectively a no-op for the spec-change path and correctly stops blocking on valid idle runners for the values-only-change path. Kept as a guarded condition rather than removed outright so that future refactors to the reconciliation flow don't silently regress into overprovisioning.

  drainingJobs() itself is unchanged — still correctly prevents double-creation of EphemeralRunnerSets at line 288.

  Testing

  - Unit/integration: added a Ginkgo regression test under Context("When updating an AutoscalingRunnerSet with running or pending jobs") that emulates 2 idle min-runners, applies a values-hash-only patch, and asserts the listener is recreated while the EphemeralRunnerSet stays intact.
  - **Manual, multi-version:** verified against three k3s clusters (k8s 1.33 / 1.34 / 1.35) spun up via k3d, using a minimal test repo (`alpine:3.23` buildx workflow) targeting the scale set. Steps:
    1. Confirmed queued jobs get picked up on the unpatched 0.13.1 controller → bump `maxRunners` in the values file and `helm upgrade -f values.yaml` → deadlock, listener never returns, queued job stays `queued`.
    2. Same sequence with this patch → listener is recreated within seconds, queued job transitions to `in_progress`, runner executes the workflow.
    3. Runner-spec change (CPU requests bumped in the values file) still drains old runners, creates a new ERS, and recreates the listener afterward — no regression.
