### PR TITLE
Add capacity-aware placeholder pod pre-warming to ghalistener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ bin
 
 
 /.tools
+
+ghalistener

--- a/cmd/ghalistener/capacity/config.go
+++ b/cmd/ghalistener/capacity/config.go
@@ -1,0 +1,144 @@
+package capacity
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// proactiveCapacityHardCap is the absolute maximum allowed value;
+	// anything larger is clamped to prevent runaway placeholder creation.
+	proactiveCapacityHardCap = 1000
+	// proactiveCapacityWarnThreshold triggers a warning log but does
+	// not clamp — operators may legitimately need >100 in surge cases.
+	proactiveCapacityWarnThreshold = 100
+)
+
+// Config holds all configuration for the capacity monitor.
+// Fields marked "set by main.go" are populated after ConfigFromEnv returns.
+type Config struct {
+	Enabled             bool
+	ProactiveCapacity   int
+	RecalculateInterval time.Duration
+	PlaceholderTimeout  time.Duration
+	MaxRunners          int
+
+	// Workflow pod resources (for placeholder-workflow sizing)
+	WorkflowCPU    string
+	WorkflowMemory string
+	WorkflowGPU    int
+	WorkflowDisk   string
+
+	// Runner pod resources (for placeholder-runner sizing)
+	RunnerCPU    string
+	RunnerMemory string
+
+	// Node placement
+	NodeFleet   string
+	RunnerClass string
+
+	// Scale set info (set by main.go, not env vars)
+	ScaleSetID     int
+	ScaleSetLabels []string
+	Namespace      string // runner namespace (EphemeralRunnerSetNamespace)
+
+	// Scale set name for label selectors (set by main.go)
+	ScaleSetName string
+
+	// HUD API
+	HUDAPIToken string
+}
+
+// ConfigFromEnv reads capacity monitor configuration from environment
+// variables. Fields that come from the listener config (MaxRunners,
+// ScaleSetID, ScaleSetLabels, Namespace, ScaleSetName) are left at
+// zero values and must be set by the caller.
+func ConfigFromEnv() Config {
+	c := Config{
+		Enabled:             envBool("CAPACITY_AWARE_ENABLED", false),
+		ProactiveCapacity:   envInt("CAPACITY_AWARE_PROACTIVE_CAPACITY", 0),
+		RecalculateInterval: envDuration("CAPACITY_AWARE_RECALCULATE_INTERVAL", 30*time.Second),
+		PlaceholderTimeout:  envDuration("CAPACITY_AWARE_PLACEHOLDER_TIMEOUT", 5*time.Minute),
+		WorkflowCPU:         envString("CAPACITY_AWARE_WORKFLOW_CPU", ""),
+		WorkflowMemory:      envString("CAPACITY_AWARE_WORKFLOW_MEMORY", ""),
+		WorkflowGPU:         envInt("CAPACITY_AWARE_WORKFLOW_GPU", 0),
+		WorkflowDisk:        envString("CAPACITY_AWARE_WORKFLOW_DISK", ""),
+		RunnerCPU:           envString("CAPACITY_AWARE_RUNNER_CPU", "750m"),
+		RunnerMemory:        envString("CAPACITY_AWARE_RUNNER_MEMORY", "512Mi"),
+		NodeFleet:           envString("CAPACITY_AWARE_NODE_FLEET", ""),
+		RunnerClass:         envString("CAPACITY_AWARE_RUNNER_CLASS", ""),
+		HUDAPIToken:         envString("CAPACITY_AWARE_HUD_API_TOKEN", ""),
+	}
+
+	if c.ProactiveCapacity < 0 {
+		slog.Warn("CAPACITY_AWARE_PROACTIVE_CAPACITY is negative, clamping to 0",
+			"original", c.ProactiveCapacity)
+		c.ProactiveCapacity = 0
+	}
+	if c.ProactiveCapacity > proactiveCapacityHardCap {
+		slog.Warn("CAPACITY_AWARE_PROACTIVE_CAPACITY exceeds hard cap, clamping",
+			"original", c.ProactiveCapacity, "cap", proactiveCapacityHardCap)
+		c.ProactiveCapacity = proactiveCapacityHardCap
+	} else if c.ProactiveCapacity > proactiveCapacityWarnThreshold {
+		slog.Warn("CAPACITY_AWARE_PROACTIVE_CAPACITY is unusually high",
+			"value", c.ProactiveCapacity, "warnThreshold", proactiveCapacityWarnThreshold)
+	}
+
+	return c
+}
+
+// Validate sanitizes fields populated by the caller (after ConfigFromEnv
+// returns). Currently clamps negative MaxRunners to 0.
+func (c *Config) Validate() {
+	if c.MaxRunners < 0 {
+		slog.Warn("MaxRunners is negative, clamping to 0",
+			"original", c.MaxRunners)
+		c.MaxRunners = 0
+	}
+}
+
+func envString(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return strings.TrimSpace(v)
+	}
+	return fallback
+}
+
+func envBool(key string, fallback bool) bool {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(v))
+	if err != nil {
+		return fallback
+	}
+	return b
+}
+
+func envInt(key string, fallback int) int {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	}
+	i, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil {
+		return fallback
+	}
+	return i
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(v))
+	if err != nil {
+		return fallback
+	}
+	return d
+}

--- a/cmd/ghalistener/capacity/config_test.go
+++ b/cmd/ghalistener/capacity/config_test.go
@@ -1,0 +1,213 @@
+package capacity
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setEnvs(t *testing.T, envs map[string]string) {
+	t.Helper()
+	for k, v := range envs {
+		prev, existed := os.LookupEnv(k)
+		os.Setenv(k, v)
+		if existed {
+			t.Cleanup(func() { os.Setenv(k, prev) })
+		} else {
+			t.Cleanup(func() { os.Unsetenv(k) })
+		}
+	}
+}
+
+func unsetEnvs(t *testing.T, keys []string) {
+	t.Helper()
+	for _, k := range keys {
+		prev, existed := os.LookupEnv(k)
+		os.Unsetenv(k)
+		if existed {
+			t.Cleanup(func() { os.Setenv(k, prev) })
+		}
+	}
+}
+
+func TestConfigFromEnv_Defaults(t *testing.T) {
+	keys := []string{
+		"CAPACITY_AWARE_ENABLED",
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY",
+		"CAPACITY_AWARE_RECALCULATE_INTERVAL",
+		"CAPACITY_AWARE_PLACEHOLDER_TIMEOUT",
+		"CAPACITY_AWARE_WORKFLOW_CPU",
+		"CAPACITY_AWARE_WORKFLOW_MEMORY",
+		"CAPACITY_AWARE_WORKFLOW_GPU",
+		"CAPACITY_AWARE_WORKFLOW_DISK",
+		"CAPACITY_AWARE_RUNNER_CPU",
+		"CAPACITY_AWARE_RUNNER_MEMORY",
+		"CAPACITY_AWARE_NODE_FLEET",
+		"CAPACITY_AWARE_RUNNER_CLASS",
+		"CAPACITY_AWARE_HUD_API_TOKEN",
+	}
+	unsetEnvs(t, keys)
+
+	cfg := ConfigFromEnv()
+
+	assert.False(t, cfg.Enabled, "Enabled default")
+	assert.Equal(t, 0, cfg.ProactiveCapacity, "ProactiveCapacity default")
+	assert.Equal(t, 30*time.Second, cfg.RecalculateInterval, "RecalculateInterval default")
+	assert.Equal(t, 5*time.Minute, cfg.PlaceholderTimeout, "PlaceholderTimeout default")
+	assert.Equal(t, "", cfg.WorkflowCPU, "WorkflowCPU default")
+	assert.Equal(t, "", cfg.WorkflowMemory, "WorkflowMemory default")
+	assert.Equal(t, 0, cfg.WorkflowGPU, "WorkflowGPU default")
+	assert.Equal(t, "", cfg.WorkflowDisk, "WorkflowDisk default")
+	assert.Equal(t, "750m", cfg.RunnerCPU, "RunnerCPU default")
+	assert.Equal(t, "512Mi", cfg.RunnerMemory, "RunnerMemory default")
+	assert.Equal(t, "", cfg.NodeFleet, "NodeFleet default")
+	assert.Equal(t, "", cfg.RunnerClass, "RunnerClass default")
+	assert.Equal(t, "", cfg.HUDAPIToken, "HUDAPIToken default")
+	// Fields set by main.go should be zero values.
+	assert.Equal(t, 0, cfg.MaxRunners, "MaxRunners zero")
+	assert.Equal(t, 0, cfg.ScaleSetID, "ScaleSetID zero")
+	assert.Nil(t, cfg.ScaleSetLabels, "ScaleSetLabels nil")
+	assert.Equal(t, "", cfg.Namespace, "Namespace zero")
+	assert.Equal(t, "", cfg.ScaleSetName, "ScaleSetName zero")
+}
+
+func TestConfigFromEnv_AllSet(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_ENABLED":              "true",
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY":   "5",
+		"CAPACITY_AWARE_RECALCULATE_INTERVAL": "10s",
+		"CAPACITY_AWARE_PLACEHOLDER_TIMEOUT":  "2m",
+		"CAPACITY_AWARE_WORKFLOW_CPU":         "4",
+		"CAPACITY_AWARE_WORKFLOW_MEMORY":      "8Gi",
+		"CAPACITY_AWARE_WORKFLOW_GPU":         "2",
+		"CAPACITY_AWARE_WORKFLOW_DISK":        "100Gi",
+		"CAPACITY_AWARE_RUNNER_CPU":           "1",
+		"CAPACITY_AWARE_RUNNER_MEMORY":        "1Gi",
+		"CAPACITY_AWARE_NODE_FLEET":           "gpu-fleet",
+		"CAPACITY_AWARE_RUNNER_CLASS":         "gpu-large",
+		"CAPACITY_AWARE_HUD_API_TOKEN":        "secret-token",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, 5, cfg.ProactiveCapacity)
+	assert.Equal(t, 10*time.Second, cfg.RecalculateInterval)
+	assert.Equal(t, 2*time.Minute, cfg.PlaceholderTimeout)
+	assert.Equal(t, "4", cfg.WorkflowCPU)
+	assert.Equal(t, "8Gi", cfg.WorkflowMemory)
+	assert.Equal(t, 2, cfg.WorkflowGPU)
+	assert.Equal(t, "100Gi", cfg.WorkflowDisk)
+	assert.Equal(t, "1", cfg.RunnerCPU)
+	assert.Equal(t, "1Gi", cfg.RunnerMemory)
+	assert.Equal(t, "gpu-fleet", cfg.NodeFleet)
+	assert.Equal(t, "gpu-large", cfg.RunnerClass)
+	assert.Equal(t, "secret-token", cfg.HUDAPIToken)
+}
+
+func TestConfigFromEnv_InvalidValues_FallbackToDefaults(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_ENABLED":              "not-a-bool",
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY":   "not-an-int",
+		"CAPACITY_AWARE_RECALCULATE_INTERVAL": "not-a-duration",
+		"CAPACITY_AWARE_PLACEHOLDER_TIMEOUT":  "999",
+		"CAPACITY_AWARE_WORKFLOW_GPU":         "abc",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.False(t, cfg.Enabled, "invalid bool falls back to false")
+	assert.Equal(t, 0, cfg.ProactiveCapacity, "invalid int falls back to 0")
+	assert.Equal(t, 30*time.Second, cfg.RecalculateInterval, "invalid duration falls back to 30s")
+	assert.Equal(t, 5*time.Minute, cfg.PlaceholderTimeout, "invalid duration falls back to 5m")
+	assert.Equal(t, 0, cfg.WorkflowGPU, "invalid int falls back to 0")
+}
+
+func TestConfigFromEnv_WhitespaceTrimmmed(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_ENABLED":            "  true  ",
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY": "  3  ",
+		"CAPACITY_AWARE_NODE_FLEET":         "  my-fleet  ",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, 3, cfg.ProactiveCapacity)
+	assert.Equal(t, "my-fleet", cfg.NodeFleet)
+}
+
+// Negative ProactiveCapacity must be clamped to 0 — never used as a
+// negative (which would underflow downstream arithmetic).
+func TestConfigFromEnv_ProactiveCapacity_NegativeClampedToZero(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY": "-5",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, 0, cfg.ProactiveCapacity,
+		"negative ProactiveCapacity must clamp to 0")
+}
+
+// Values above the hard cap (1000) must be clamped — protects against
+// runaway placeholder creation from a misconfiguration.
+func TestConfigFromEnv_ProactiveCapacity_AboveHardCapClamped(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY": "5000",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, proactiveCapacityHardCap, cfg.ProactiveCapacity,
+		"value above hard cap must clamp to %d", proactiveCapacityHardCap)
+}
+
+// Values exactly at the hard cap are allowed (boundary).
+func TestConfigFromEnv_ProactiveCapacity_AtHardCapAllowed(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY": "1000",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, proactiveCapacityHardCap, cfg.ProactiveCapacity,
+		"value exactly at hard cap must be preserved")
+}
+
+// Values above the warn threshold (100) but below the hard cap (1000)
+// are allowed unchanged — operators may legitimately need this in surge.
+func TestConfigFromEnv_ProactiveCapacity_AboveWarnAllowed(t *testing.T) {
+	setEnvs(t, map[string]string{
+		"CAPACITY_AWARE_PROACTIVE_CAPACITY": "250",
+	})
+
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, 250, cfg.ProactiveCapacity,
+		"values between warn threshold and hard cap are allowed")
+}
+
+// Validate() clamps negative MaxRunners (set by main.go after env parse).
+func TestConfig_Validate_MaxRunnersNegativeClamped(t *testing.T) {
+	cfg := Config{MaxRunners: -3}
+	cfg.Validate()
+	assert.Equal(t, 0, cfg.MaxRunners,
+		"Validate must clamp negative MaxRunners to 0")
+}
+
+func TestConfig_Validate_MaxRunnersZeroPreserved(t *testing.T) {
+	cfg := Config{MaxRunners: 0}
+	cfg.Validate()
+	assert.Equal(t, 0, cfg.MaxRunners,
+		"Validate preserves MaxRunners=0 (means unlimited downstream)")
+}
+
+func TestConfig_Validate_MaxRunnersPositivePreserved(t *testing.T) {
+	cfg := Config{MaxRunners: 42}
+	cfg.Validate()
+	assert.Equal(t, 42, cfg.MaxRunners,
+		"Validate preserves positive MaxRunners")
+}

--- a/cmd/ghalistener/capacity/hud_client.go
+++ b/cmd/ghalistener/capacity/hud_client.go
@@ -1,0 +1,87 @@
+package capacity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	hudAPIURL = "https://hud.pytorch.org/api/clickhouse/queued_jobs_aggregate"
+	// hudResponseMaxBytes caps the JSON payload we will read from the
+	// HUD API. A misbehaving or compromised endpoint must not be able
+	// to OOM the listener by streaming an unbounded response.
+	hudResponseMaxBytes = 10 * 1024 * 1024 // 10 MiB
+)
+
+// QueuedJobsForRunner represents a single row from the HUD API response.
+type QueuedJobsForRunner struct {
+	RunnerLabel         string  `json:"runner_label"`
+	Org                 string  `json:"org"`
+	Repo                string  `json:"repo"`
+	NumQueuedJobs       int     `json:"num_queued_jobs"`
+	MinQueueTimeMinutes float64 `json:"min_queue_time_minutes"`
+	MaxQueueTimeMinutes float64 `json:"max_queue_time_minutes"`
+}
+
+// HUDClient is an HTTP client for the PyTorch HUD API that returns
+// aggregate queued job counts per runner label.
+type HUDClient struct {
+	token  string
+	client *http.Client
+}
+
+// NewHUDClient creates a new HUD API client with the given auth token.
+func NewHUDClient(token string) *HUDClient {
+	return &HUDClient{
+		token:  token,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// GetQueuedJobsForLabels queries the HUD API and returns the total
+// number of queued jobs matching any of the provided runner labels.
+// On any error the caller receives (0, err) and decides the fallback.
+func (c *HUDClient) GetQueuedJobsForLabels(ctx context.Context, labels []string) (int, error) {
+	if len(labels) == 0 {
+		return 0, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hudAPIURL+"?parameters=%5B%5D", nil)
+	if err != nil {
+		return 0, fmt.Errorf("building HUD request: %w", err)
+	}
+	req.Header.Set("x-hud-internal-bot", c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("HUD API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("HUD API returned status %d", resp.StatusCode)
+	}
+
+	var rows []QueuedJobsForRunner
+	body := io.LimitReader(resp.Body, hudResponseMaxBytes)
+	if err := json.NewDecoder(body).Decode(&rows); err != nil {
+		return 0, fmt.Errorf("decoding HUD response: %w", err)
+	}
+
+	labelSet := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		labelSet[l] = struct{}{}
+	}
+
+	total := 0
+	for _, row := range rows {
+		if _, ok := labelSet[row.RunnerLabel]; ok {
+			total += row.NumQueuedJobs
+		}
+	}
+	return total, nil
+}

--- a/cmd/ghalistener/capacity/hud_client_test.go
+++ b/cmd/ghalistener/capacity/hud_client_test.go
@@ -1,0 +1,156 @@
+package capacity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestHUDClient(t *testing.T, handler http.HandlerFunc) (*HUDClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	client := &HUDClient{
+		token:  "test-token",
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+	// Override the package-level URL by patching the client to hit our server.
+	// Since hudAPIURL is a const, we override via a custom transport.
+	origURL := srv.URL
+	client.client.Transport = &rewriteTransport{base: http.DefaultTransport, target: origURL}
+	return client, srv.Close
+}
+
+// rewriteTransport redirects all requests to the test server.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = t.target[len("http://"):]
+	return t.base.RoundTrip(req)
+}
+
+func TestGetQueuedJobsForLabels_HappyPath(t *testing.T) {
+	rows := []QueuedJobsForRunner{
+		{RunnerLabel: "linux.2xlarge", NumQueuedJobs: 10},
+		{RunnerLabel: "linux.4xlarge", NumQueuedJobs: 5},
+		{RunnerLabel: "linux.gpu.a100", NumQueuedJobs: 3},
+	}
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "test-token", r.Header.Get("x-hud-internal-bot"))
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(rows)
+	})
+	defer cleanup()
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"linux.2xlarge"})
+	require.NoError(t, err)
+	assert.Equal(t, 10, total)
+}
+
+func TestGetQueuedJobsForLabels_NoMatchingLabels(t *testing.T) {
+	rows := []QueuedJobsForRunner{
+		{RunnerLabel: "linux.2xlarge", NumQueuedJobs: 10},
+	}
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(rows)
+	})
+	defer cleanup()
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"windows.large"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+}
+
+func TestGetQueuedJobsForLabels_MultipleMatchingLabels(t *testing.T) {
+	rows := []QueuedJobsForRunner{
+		{RunnerLabel: "linux.2xlarge", NumQueuedJobs: 10},
+		{RunnerLabel: "linux.4xlarge", NumQueuedJobs: 5},
+		{RunnerLabel: "linux.gpu.a100", NumQueuedJobs: 3},
+	}
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(rows)
+	})
+	defer cleanup()
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"linux.2xlarge", "linux.gpu.a100"})
+	require.NoError(t, err)
+	assert.Equal(t, 13, total)
+}
+
+func TestGetQueuedJobsForLabels_EmptyLabels(t *testing.T) {
+	client := NewHUDClient("token")
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+}
+
+func TestGetQueuedJobsForLabels_ServerError(t *testing.T) {
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer cleanup()
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"linux.2xlarge"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+	assert.Equal(t, 0, total)
+}
+
+func TestGetQueuedJobsForLabels_Timeout(t *testing.T) {
+	// Use a channel so the handler blocks until the test signals it to stop,
+	// preventing httptest.Server.Close from waiting for the handler goroutine.
+	done := make(chan struct{})
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		<-done
+	})
+	defer func() { close(done); cleanup() }()
+	client.client.Timeout = 50 * time.Millisecond
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"linux.2xlarge"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HUD API request failed")
+	assert.Equal(t, 0, total)
+}
+
+func TestGetQueuedJobsForLabels_MalformedJSON(t *testing.T) {
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("this is not json"))
+	})
+	defer cleanup()
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"linux.2xlarge"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding HUD response")
+	assert.Equal(t, 0, total)
+}
+
+func TestGetQueuedJobsForLabels_EmptyToken(t *testing.T) {
+	rows := []QueuedJobsForRunner{
+		{RunnerLabel: "linux.2xlarge", NumQueuedJobs: 7},
+	}
+	client, cleanup := newTestHUDClient(t, func(w http.ResponseWriter, r *http.Request) {
+		// Token header should be set even if empty.
+		assert.Equal(t, "", r.Header.Get("x-hud-internal-bot"))
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(rows)
+	})
+	defer cleanup()
+	client.token = ""
+
+	total, err := client.GetQueuedJobsForLabels(context.Background(), []string{"linux.2xlarge"})
+	require.NoError(t, err)
+	assert.Equal(t, 7, total)
+}

--- a/cmd/ghalistener/capacity/monitor.go
+++ b/cmd/ghalistener/capacity/monitor.go
@@ -1,0 +1,234 @@
+package capacity
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Monitor is the capacity monitor goroutine. It creates placeholder
+// pod pairs to pre-warm Kubernetes nodes, queries the HUD API for
+// queued job counts, and dynamically adjusts the maxRunners value
+// reported to GitHub via the listener.
+type Monitor struct {
+	config        Config
+	placeholders  *PlaceholderManager
+	hudClient     *HUDClient
+	clientset     kubernetes.Interface
+	setMaxRunners func(int)
+	logger        *slog.Logger
+	slotCounter   int // monotonic counter for unique slot IDs
+}
+
+// New creates a new capacity Monitor. The setMaxRunners callback is
+// typically listener.SetMaxRunners.
+func New(
+	config Config,
+	clientset kubernetes.Interface,
+	setMaxRunners func(int),
+	logger *slog.Logger,
+) *Monitor {
+	config.Validate()
+	listenerID, _ := os.Hostname()
+	return &Monitor{
+		config: config,
+		placeholders: NewPlaceholderManager(
+			clientset,
+			config.Namespace,
+			listenerID,
+			config,
+			logger,
+		),
+		hudClient:     NewHUDClient(config.HUDAPIToken),
+		clientset:     clientset,
+		setMaxRunners: setMaxRunners,
+		logger:        logger.With("component", "capacity-monitor"),
+	}
+}
+
+// Run starts the capacity monitor loop. It blocks until ctx is
+// cancelled, then cleans up all placeholder pods before returning.
+func (m *Monitor) Run(ctx context.Context) error {
+	m.logger.Info("starting capacity monitor",
+		"proactiveCapacity", m.config.ProactiveCapacity,
+		"maxRunners", m.config.MaxRunners,
+		"labels", m.config.ScaleSetLabels,
+		"recalculateInterval", m.config.RecalculateInterval,
+	)
+
+	// Clean up orphaned placeholders from previous listener instances.
+	if err := m.placeholders.CleanupOrphans(ctx); err != nil {
+		m.logger.Warn("failed to cleanup orphaned placeholders", "error", err)
+	}
+
+	// Initial reconciliation.
+	m.reconcile(ctx)
+
+	ticker := time.NewTicker(m.config.RecalculateInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.Info("shutting down capacity monitor, cleaning up placeholders")
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := m.placeholders.CleanupAll(cleanupCtx); err != nil {
+				m.logger.Error("failed to cleanup placeholders on shutdown", "error", err)
+			}
+			return ctx.Err()
+		case <-ticker.C:
+			m.reconcile(ctx)
+		}
+	}
+}
+
+func (m *Monitor) reconcile(ctx context.Context) {
+	// 1. Query HUD API for queued jobs (graceful fallback to 0 on error).
+	queuedJobs := 0
+	if m.hudClient != nil && m.config.HUDAPIToken != "" {
+		var err error
+		queuedJobs, err = m.hudClient.GetQueuedJobsForLabels(ctx, m.config.ScaleSetLabels)
+		if err != nil {
+			m.logger.Warn("HUD API query failed, using 0 queued jobs", "error", err)
+			queuedJobs = 0
+		}
+	}
+
+	// 2. Cleanup timed-out placeholder pairs.
+	timedOut, err := m.placeholders.CleanupTimedOut(ctx)
+	if err != nil {
+		m.logger.Warn("failed to cleanup timed out placeholders", "error", err)
+	} else if timedOut > 0 {
+		m.logger.Info("cleaned up timed-out placeholder pairs", "count", timedOut)
+	}
+
+	// 3. Get current placeholder state.
+	pairs, err := m.placeholders.ListPairs(ctx)
+	if err != nil {
+		m.logger.Error("failed to list placeholder pairs", "error", err)
+		return
+	}
+
+	runningPairs := 0
+	for _, pair := range pairs {
+		if pair.BothRunning() {
+			runningPairs++
+		}
+	}
+	currentPairs := len(pairs)
+
+	// 4. Count running ephemeral runners (actual jobs on nodes).
+	runningRunners := m.countRunningRunners(ctx)
+
+	// 5. Calculate desired placeholder count.
+	// MaxRunners == 0 means unlimited (not "zero capacity") — skip the cap.
+	desiredPairs := m.config.ProactiveCapacity + queuedJobs
+	if m.config.MaxRunners > 0 {
+		desiredPairs = min(desiredPairs, m.config.MaxRunners)
+	}
+	desiredPairs = max(desiredPairs, 0)
+
+	// 6. Adjust: create or delete pairs.
+	m.adjustPairs(ctx, pairs, currentPairs, desiredPairs)
+
+	// 7. Report capacity to GitHub.
+	// capacity = running runners (actual jobs) + running placeholder pairs
+	// (pre-warmed nodes), capped at maxRunners (when set; 0 means unlimited).
+	capacity := runningRunners + runningPairs
+	if m.config.MaxRunners > 0 {
+		capacity = min(capacity, m.config.MaxRunners)
+	}
+	m.setMaxRunners(capacity)
+
+	m.logger.Info("capacity reconciled",
+		"queuedJobs", queuedJobs,
+		"desiredPairs", desiredPairs,
+		"currentPairs", currentPairs,
+		"runningPairs", runningPairs,
+		"runningRunners", runningRunners,
+		"reportedCapacity", capacity,
+	)
+}
+
+// countRunningRunners lists EphemeralRunner pods that are actually
+// running jobs for this scale set.
+func (m *Monitor) countRunningRunners(ctx context.Context) int {
+	sel := fmt.Sprintf("actions-ephemeral-runner=True,%s=%s",
+		labelScaleSet, m.config.ScaleSetName,
+	)
+	pods, err := m.clientset.CoreV1().Pods(m.config.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: sel,
+	})
+	if err != nil {
+		m.logger.Warn("failed to list running runners", "error", err)
+		return 0
+	}
+	return len(pods.Items)
+}
+
+func (m *Monitor) adjustPairs(
+	ctx context.Context,
+	pairs map[string]*PlaceholderPair,
+	currentPairs, desiredPairs int,
+) {
+	if currentPairs < desiredPairs {
+		toCreate := desiredPairs - currentPairs
+		for i := 0; i < toCreate; i++ {
+			m.slotCounter++
+			slotID := fmt.Sprintf("%d-%d", time.Now().Unix(), m.slotCounter)
+			if err := m.placeholders.CreatePair(ctx, slotID); err != nil {
+				m.logger.Error("failed to create placeholder pair",
+					"slotID", slotID, "error", err)
+			}
+		}
+		return
+	}
+
+	if currentPairs <= desiredPairs {
+		return
+	}
+
+	toDelete := currentPairs - desiredPairs
+	deleted := 0
+	// Track slotIDs deleted in pass 1 so pass 2 doesn't re-delete them.
+	deletedSlots := make(map[string]struct{})
+
+	// First pass: prefer deleting non-running (Pending) pairs.
+	for slotID, pair := range pairs {
+		if deleted >= toDelete {
+			break
+		}
+		if !pair.BothRunning() {
+			if err := m.placeholders.DeletePair(ctx, slotID); err != nil {
+				m.logger.Error("failed to delete placeholder pair",
+					"slotID", slotID, "error", err)
+				continue
+			}
+			deletedSlots[slotID] = struct{}{}
+			deleted++
+		}
+	}
+
+	// Second pass: delete running pairs if we still need to reduce.
+	for slotID := range pairs {
+		if deleted >= toDelete {
+			break
+		}
+		if _, alreadyDeleted := deletedSlots[slotID]; alreadyDeleted {
+			continue
+		}
+		if err := m.placeholders.DeletePair(ctx, slotID); err != nil {
+			m.logger.Error("failed to delete placeholder pair",
+				"slotID", slotID, "error", err)
+			continue
+		}
+		deletedSlots[slotID] = struct{}{}
+		deleted++
+	}
+}

--- a/cmd/ghalistener/capacity/monitor_test.go
+++ b/cmd/ghalistener/capacity/monitor_test.go
@@ -1,0 +1,387 @@
+package capacity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// newTestMonitor creates a Monitor wired to a fake K8s client (with
+// working DeleteCollection) and an optional HUD test server. If hudRows
+// is nil, no HUD server is created and the monitor falls back to
+// proactiveCapacity only.
+func newTestMonitor(t *testing.T, cfg Config, hudRows []QueuedJobsForRunner) (*Monitor, *fake.Clientset, *atomic.Int32) {
+	t.Helper()
+	if cfg.Namespace == "" {
+		cfg.Namespace = "test-ns"
+	}
+	if cfg.ScaleSetName == "" {
+		cfg.ScaleSetName = "test-sset"
+	}
+	cs := newFakeClientset()
+
+	var maxRunnersVal atomic.Int32
+	setMax := func(v int) { maxRunnersVal.Store(int32(v)) }
+
+	logger := discardLogger
+	listenerID := "test-listener"
+
+	m := &Monitor{
+		config: cfg,
+		placeholders: NewPlaceholderManager(
+			cs, cfg.Namespace, listenerID, cfg, logger,
+		),
+		clientset:     cs,
+		setMaxRunners: setMax,
+		logger:        logger.With("component", "capacity-monitor"),
+	}
+
+	if hudRows != nil {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(hudRows)
+		}))
+		t.Cleanup(srv.Close)
+
+		hc := &HUDClient{
+			token:  "test",
+			client: &http.Client{Timeout: 5 * time.Second},
+		}
+		hc.client.Transport = &rewriteTransport{
+			base:   http.DefaultTransport,
+			target: srv.URL,
+		}
+		m.hudClient = hc
+		cfg.HUDAPIToken = "test"
+		m.config = cfg
+	}
+
+	return m, cs, &maxRunnersVal
+}
+
+func countPods(t *testing.T, cs *fake.Clientset, ns string) int {
+	t.Helper()
+	pods, err := cs.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	return len(pods.Items)
+}
+
+func TestReconcile_ZeroQueued_CreatesProactiveCapacity(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:  3,
+		MaxRunners:         10,
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, nil)
+
+	m.reconcile(context.Background())
+
+	// 3 pairs = 6 pods.
+	assert.Equal(t, 6, countPods(t, cs, "test-ns"))
+	// No running pairs (fake client pods start with empty phase), so
+	// setMaxRunners(min(0+0, 10)) = 0.
+	assert.Equal(t, int32(0), maxVal.Load())
+}
+
+func TestReconcile_QueuedJobs_AddsToProactiveCapacity(t *testing.T) {
+	hudRows := []QueuedJobsForRunner{
+		{RunnerLabel: "linux.2xlarge", NumQueuedJobs: 5},
+	}
+	cfg := Config{
+		ProactiveCapacity:  2,
+		MaxRunners:         20,
+		ScaleSetLabels:     []string{"linux.2xlarge"},
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, hudRows)
+
+	m.reconcile(context.Background())
+
+	// desired = proactive(2) + queued(5) = 7 pairs = 14 pods.
+	assert.Equal(t, 14, countPods(t, cs, "test-ns"))
+	// No running pairs/runners yet, so capacity = 0.
+	assert.Equal(t, int32(0), maxVal.Load())
+}
+
+func TestReconcile_MaxRunnersCap(t *testing.T) {
+	hudRows := []QueuedJobsForRunner{
+		{RunnerLabel: "linux.2xlarge", NumQueuedJobs: 50},
+	}
+	cfg := Config{
+		ProactiveCapacity:  5,
+		MaxRunners:         10,
+		ScaleSetLabels:     []string{"linux.2xlarge"},
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, hudRows)
+
+	m.reconcile(context.Background())
+
+	// desired = min(5+50, 10) = 10 pairs = 20 pods.
+	assert.Equal(t, 20, countPods(t, cs, "test-ns"))
+	// No running pairs/runners, so reported capacity = 0 (capped at MaxRunners=10).
+	assert.Equal(t, int32(0), maxVal.Load())
+}
+
+func TestReconcile_ScaleDown_PrefersPendingDeletion(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:  5,
+		MaxRunners:         20,
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, nil)
+	ctx := context.Background()
+
+	// First reconcile creates 5 pairs.
+	m.reconcile(ctx)
+	assert.Equal(t, 10, countPods(t, cs, "test-ns"))
+
+	// Make 2 pairs Running, leave 3 Pending.
+	pairs, err := m.placeholders.ListPairs(ctx)
+	require.NoError(t, err)
+	runningCount := 0
+	for slotID := range pairs {
+		if runningCount < 2 {
+			setPodsPhase(t, cs, ctx, "test-ns", slotID, corev1.PodRunning)
+			runningCount++
+		} else {
+			setPodsPhase(t, cs, ctx, "test-ns", slotID, corev1.PodPending)
+		}
+	}
+
+	// Scale down to 2 pairs.
+	m.config.ProactiveCapacity = 2
+	m.reconcile(ctx)
+
+	// Should have deleted EXACTLY 3 pairs (the 3 Pending ones), not more
+	// (regression test for adjustPairs double-delete counter bug).
+	assert.Equal(t, 4, countPods(t, cs, "test-ns"),
+		"must delete exactly 3 pairs (the Pending ones), leaving the 2 Running pairs")
+
+	// Verify the remaining pods are the Running ones.
+	remaining, err := m.placeholders.ListPairs(ctx)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 2, "exactly 2 pairs remain")
+	for _, pair := range remaining {
+		assert.True(t, pair.BothRunning(), "remaining pairs should be running")
+	}
+	// 2 running pairs, 0 running runners, capped at MaxRunners=20.
+	assert.Equal(t, int32(2), maxVal.Load())
+}
+
+// Regression test for the adjustPairs double-delete bug: when scaling
+// from 5 to 2 with all pairs Pending, ensure exactly 3 are deleted —
+// not over-deleted (the bug double-counted slots in pass 2 when pass 1
+// had already deleted them).
+func TestAdjustPairs_NoDoubleDelete_AllPending(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:  5,
+		MaxRunners:         20,
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, _ := newTestMonitor(t, cfg, nil)
+	ctx := context.Background()
+
+	// Create 5 pairs, all Pending.
+	m.reconcile(ctx)
+	pairs, err := m.placeholders.ListPairs(ctx)
+	require.NoError(t, err)
+	for slotID := range pairs {
+		setPodsPhase(t, cs, ctx, "test-ns", slotID, corev1.PodPending)
+	}
+	assert.Equal(t, 10, countPods(t, cs, "test-ns"))
+
+	// Scale down to 2 pairs.
+	m.config.ProactiveCapacity = 2
+	m.reconcile(ctx)
+
+	// EXACTLY 3 pairs should be deleted (6 pods removed -> 4 remaining).
+	// If the double-delete bug returned, fewer (or wrong) pairs would
+	// remain because pass 2 would skip slots already deleted by pass 1
+	// without correctly accounting for them.
+	assert.Equal(t, 4, countPods(t, cs, "test-ns"),
+		"exactly 3 pairs deleted, 2 remain")
+}
+
+func TestReconcile_SetMaxRunners_CapAtMaxRunners(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:  2,
+		MaxRunners:         5,
+		ScaleSetName:       "test-sset",
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, nil)
+	ctx := context.Background()
+
+	// Create some "real" ephemeral runner pods.
+	for i := 0; i < 3; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "runner-" + string(rune('a'+i)),
+				Namespace: "test-ns",
+				Labels: map[string]string{
+					"actions-ephemeral-runner": "True",
+					labelScaleSet:              "test-sset",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "runner", Image: "runner:latest"}},
+			},
+		}
+		_, err := cs.CoreV1().Pods("test-ns").Create(ctx, pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	m.reconcile(ctx)
+
+	// Make placeholder pairs Running.
+	pairs, _ := m.placeholders.ListPairs(ctx)
+	for slotID := range pairs {
+		setPodsPhase(t, cs, ctx, "test-ns", slotID, corev1.PodRunning)
+	}
+
+	m.reconcile(ctx)
+
+	// capacity = min(runningRunners(3) + runningPairs(2), maxRunners(5)) = 5.
+	assert.Equal(t, int32(5), maxVal.Load())
+}
+
+func TestReconcile_HUDAPIFailure_FallsBackToProactiveOnly(t *testing.T) {
+	// HUD server returns 500.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		ProactiveCapacity:  3,
+		MaxRunners:         20,
+		ScaleSetLabels:     []string{"linux.2xlarge"},
+		HUDAPIToken:        "test",
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, nil)
+
+	// Wire up the failing HUD server.
+	hc := &HUDClient{
+		token:  "test",
+		client: &http.Client{Timeout: 5 * time.Second},
+	}
+	hc.client.Transport = &rewriteTransport{
+		base:   http.DefaultTransport,
+		target: srv.URL,
+	}
+	m.hudClient = hc
+
+	m.reconcile(context.Background())
+
+	// Falls back to proactiveCapacity only: 3 pairs = 6 pods.
+	assert.Equal(t, 6, countPods(t, cs, "test-ns"))
+	// No running pairs, so capacity = 0 (still capped at MaxRunners=20).
+	assert.Equal(t, int32(0), maxVal.Load())
+}
+
+func TestReconcile_IdempotentWhenAtDesired(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:  2,
+		MaxRunners:         10,
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, nil)
+
+	m.reconcile(context.Background())
+	assert.Equal(t, 4, countPods(t, cs, "test-ns"))
+	assert.Equal(t, int32(0), maxVal.Load(),
+		"no running pairs after first reconcile -> capacity 0")
+
+	// Second reconcile should not change anything.
+	m.reconcile(context.Background())
+	assert.Equal(t, 4, countPods(t, cs, "test-ns"))
+	assert.Equal(t, int32(0), maxVal.Load(),
+		"second reconcile preserves capacity 0")
+}
+
+// MaxRunners == 0 means "unlimited" (not "zero capacity"). The monitor
+// must create placeholders normally and report capacity = running
+// runners + running pairs without capping at 0.
+// Regression test for the MaxRunners==0 deadlock bug.
+func TestReconcile_MaxRunnersZero_IsUnlimited(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:  3,
+		MaxRunners:         0, // unlimited
+		PlaceholderTimeout: 5 * time.Minute,
+	}
+	m, cs, maxVal := newTestMonitor(t, cfg, nil)
+	ctx := context.Background()
+
+	m.reconcile(ctx)
+
+	// 3 pairs = 6 pods (NOT capped at 0).
+	assert.Equal(t, 6, countPods(t, cs, "test-ns"),
+		"MaxRunners=0 must NOT cap placeholders at 0")
+	// No running pairs yet -> capacity = 0 (not because of cap).
+	assert.Equal(t, int32(0), maxVal.Load())
+
+	// Make all pairs Running and add some real runner pods.
+	pairs, _ := m.placeholders.ListPairs(ctx)
+	for slotID := range pairs {
+		setPodsPhase(t, cs, ctx, "test-ns", slotID, corev1.PodRunning)
+	}
+	for i := 0; i < 7; i++ {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "runner-" + string(rune('a'+i)),
+				Namespace: "test-ns",
+				Labels: map[string]string{
+					"actions-ephemeral-runner": "True",
+					labelScaleSet:              "test-sset",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "r", Image: "x"}},
+			},
+		}
+		_, err := cs.CoreV1().Pods("test-ns").Create(ctx, pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	m.reconcile(ctx)
+
+	// capacity = runningRunners(7) + runningPairs(3) = 10, NOT capped.
+	assert.Equal(t, int32(10), maxVal.Load(),
+		"MaxRunners=0 must NOT cap reported capacity")
+	// Still 3 pairs (proactive=3, no queued, no MaxRunners cap).
+	pairs, _ = m.placeholders.ListPairs(ctx)
+	assert.Len(t, pairs, 3)
+}
+
+func TestRunLoop_CancellationCleansUp(t *testing.T) {
+	cfg := Config{
+		ProactiveCapacity:   1,
+		MaxRunners:          5,
+		RecalculateInterval: 100 * time.Millisecond,
+		PlaceholderTimeout:  5 * time.Minute,
+	}
+	m, cs, _ := newTestMonitor(t, cfg, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err := m.Run(ctx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// After Run returns, all placeholders should be cleaned up.
+	pods, listErr := cs.CoreV1().Pods("test-ns").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items, "all placeholders cleaned up on shutdown")
+}

--- a/cmd/ghalistener/capacity/placeholder.go
+++ b/cmd/ghalistener/capacity/placeholder.go
@@ -1,0 +1,494 @@
+package capacity
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	placeholderImage = "public.ecr.aws/docker/library/alpine:3.21"
+
+	labelManagedBy       = "app.kubernetes.io/managed-by"
+	labelScaleSet        = "actions.github.com/scale-set-name"
+	labelPlaceholderID   = "capacity.actions.github.com/slot-id"
+	labelPlaceholderRole = "capacity.actions.github.com/role"
+	labelListenerPod     = "capacity.actions.github.com/listener-pod"
+
+	managedByValue = "capacity-monitor"
+
+	rolePlaceholderRunner   = "placeholder-runner"
+	rolePlaceholderWorkflow = "placeholder-workflow"
+
+	maxPodNameLen = 63
+)
+
+// PlaceholderPair groups the runner and workflow placeholder pods for a
+// single pre-warmed slot.
+type PlaceholderPair struct {
+	SlotID      string
+	RunnerPod   *corev1.Pod
+	WorkflowPod *corev1.Pod
+	CreatedAt   time.Time
+}
+
+// BothRunning returns true when both pods in the pair are in the
+// Running phase.
+func (p *PlaceholderPair) BothRunning() bool {
+	return p.RunnerPod != nil && p.WorkflowPod != nil &&
+		p.RunnerPod.Status.Phase == corev1.PodRunning &&
+		p.WorkflowPod.Status.Phase == corev1.PodRunning
+}
+
+// AnyPendingTooLong returns true if either pod has been in the Pending
+// phase longer than timeout.
+func (p *PlaceholderPair) AnyPendingTooLong(timeout time.Duration) bool {
+	now := time.Now()
+	for _, pod := range []*corev1.Pod{p.RunnerPod, p.WorkflowPod} {
+		if pod == nil {
+			continue
+		}
+		if pod.Status.Phase == corev1.PodPending &&
+			now.Sub(pod.CreationTimestamp.Time) > timeout {
+			return true
+		}
+	}
+	return false
+}
+
+// PlaceholderManager creates, lists, and cleans up placeholder pod
+// pairs via the Kubernetes API.
+type PlaceholderManager struct {
+	clientset  kubernetes.Interface
+	namespace  string
+	listenerID string // listener pod name, used for label-based ownership
+	config     Config
+	logger     *slog.Logger
+}
+
+// NewPlaceholderManager creates a new manager.
+func NewPlaceholderManager(
+	clientset kubernetes.Interface,
+	namespace string,
+	listenerID string,
+	config Config,
+	logger *slog.Logger,
+) *PlaceholderManager {
+	return &PlaceholderManager{
+		clientset:  clientset,
+		namespace:  namespace,
+		listenerID: listenerID,
+		config:     config,
+		logger:     logger.With("component", "placeholder-manager"),
+	}
+}
+
+// CreatePair creates a placeholder-runner and placeholder-workflow pod
+// pair. Both pods are scheduled independently (landing-place agnostic)
+// to reserve cluster-level capacity.
+func (pm *PlaceholderManager) CreatePair(ctx context.Context, slotID string) error {
+	runnerPod := pm.buildRunnerPlaceholder(slotID)
+	if _, err := pm.clientset.CoreV1().Pods(pm.namespace).Create(ctx, runnerPod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("creating runner placeholder: %w", err)
+	}
+
+	workflowPod := pm.buildWorkflowPlaceholder(slotID)
+	if _, err := pm.clientset.CoreV1().Pods(pm.namespace).Create(ctx, workflowPod, metav1.CreateOptions{}); err != nil {
+		// Best-effort cleanup of the runner pod we already created.
+		_ = pm.clientset.CoreV1().Pods(pm.namespace).Delete(ctx, runnerPod.Name, metav1.DeleteOptions{})
+		return fmt.Errorf("creating workflow placeholder: %w", err)
+	}
+	return nil
+}
+
+// DeletePair deletes both pods in a placeholder pair by slot ID.
+func (pm *PlaceholderManager) DeletePair(ctx context.Context, slotID string) error {
+	sel := fmt.Sprintf("%s=%s,%s=%s,%s=%s",
+		labelManagedBy, managedByValue,
+		labelListenerPod, pm.listenerID,
+		labelPlaceholderID, slotID,
+	)
+	return pm.clientset.CoreV1().Pods(pm.namespace).DeleteCollection(
+		ctx,
+		metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: sel},
+	)
+}
+
+// ListPairs returns all placeholder pairs owned by this listener,
+// grouped by slot ID.
+func (pm *PlaceholderManager) ListPairs(ctx context.Context) (map[string]*PlaceholderPair, error) {
+	sel := fmt.Sprintf("%s=%s,%s=%s",
+		labelManagedBy, managedByValue,
+		labelListenerPod, pm.listenerID,
+	)
+	pods, err := pm.clientset.CoreV1().Pods(pm.namespace).List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err != nil {
+		return nil, fmt.Errorf("listing placeholder pods: %w", err)
+	}
+	return groupBySlot(pods.Items), nil
+}
+
+// CleanupTimedOut deletes pairs where any pod has been Pending longer
+// than PlaceholderTimeout. Returns the number of pairs deleted.
+func (pm *PlaceholderManager) CleanupTimedOut(ctx context.Context) (int, error) {
+	pairs, err := pm.ListPairs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for slotID, pair := range pairs {
+		if pair.AnyPendingTooLong(pm.config.PlaceholderTimeout) {
+			if err := pm.DeletePair(ctx, slotID); err != nil {
+				pm.logger.Error("failed to delete timed-out pair", "slotID", slotID, "error", err)
+				continue
+			}
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// CleanupOrphans deletes placeholder pods from previous listener
+// instances of the SAME scale set (different listener-pod label value
+// but same scale-set-name label). Scoping to scale set prevents
+// listeners from deleting each other's placeholders.
+func (pm *PlaceholderManager) CleanupOrphans(ctx context.Context) error {
+	sel := fmt.Sprintf("%s=%s,%s=%s,%s!=%s",
+		labelManagedBy, managedByValue,
+		labelScaleSet, pm.config.ScaleSetName,
+		labelListenerPod, pm.listenerID,
+	)
+	return pm.clientset.CoreV1().Pods(pm.namespace).DeleteCollection(
+		ctx,
+		metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: sel},
+	)
+}
+
+// CleanupAll deletes all placeholder pods owned by this listener.
+func (pm *PlaceholderManager) CleanupAll(ctx context.Context) error {
+	sel := fmt.Sprintf("%s=%s,%s=%s",
+		labelManagedBy, managedByValue,
+		labelListenerPod, pm.listenerID,
+	)
+	return pm.clientset.CoreV1().Pods(pm.namespace).DeleteCollection(
+		ctx,
+		metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: sel},
+	)
+}
+
+// ---- pod builders ----
+
+// setQuantity safely parses raw and assigns it to both Requests[name] and
+// Limits[name] (mirroring the template, which sets equal request/limit).
+// Logs and skips on parse error rather than panicking.
+func (pm *PlaceholderManager) setQuantity(
+	res *corev1.ResourceRequirements,
+	name corev1.ResourceName,
+	raw string,
+	configKey string,
+) {
+	if raw == "" {
+		return
+	}
+	q, err := resource.ParseQuantity(raw)
+	if err != nil {
+		pm.logger.Warn("invalid resource quantity, skipping",
+			"configKey", configKey, "value", raw, "error", err)
+		return
+	}
+	res.Requests[name] = q
+	res.Limits[name] = q
+}
+
+// buildRunnerPlaceholder constructs a placeholder pod that mirrors the
+// runner pod spec defined in modules/arc-runners/templates/runner.yaml.tpl
+// (the `template:` section). Specs MUST stay in sync with that template.
+func (pm *PlaceholderManager) buildRunnerPlaceholder(slotID string) *corev1.Pod {
+	name := truncatePodName(fmt.Sprintf("ph-r-%s-%s", pm.config.ScaleSetName, slotID))
+
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+	pm.setQuantity(&resources, corev1.ResourceCPU, pm.config.RunnerCPU, "RunnerCPU")
+	pm.setQuantity(&resources, corev1.ResourceMemory, pm.config.RunnerMemory, "RunnerMemory")
+
+	// Runner nodeSelector: workload-type, node-fleet, optional runner-class.
+	nodeSelector := map[string]string{
+		"workload-type": "github-runner",
+	}
+	if pm.config.NodeFleet != "" {
+		nodeSelector["node-fleet"] = pm.config.NodeFleet
+	}
+	if pm.config.RunnerClass != "" {
+		nodeSelector["osdc.io/runner-class"] = pm.config.RunnerClass
+	}
+
+	// Runner tolerations: node-fleet, instance-type Exists, git-cache-not-ready,
+	// plus optional GPU and runner-class. NOT workload-type (that's a node label).
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "instance-type",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "git-cache-not-ready",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	if pm.config.NodeFleet != "" {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "node-fleet",
+			Operator: corev1.TolerationOpEqual,
+			Value:    pm.config.NodeFleet,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+	if pm.config.WorkflowGPU > 0 {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "nvidia.com/gpu",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+	if pm.config.RunnerClass != "" {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "osdc.io/runner-class",
+			Operator: corev1.TolerationOpEqual,
+			Value:    pm.config.RunnerClass,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+
+	pod := pm.placeholderPodShell(name, slotID, rolePlaceholderRunner, resources)
+	pod.Spec.NodeSelector = nodeSelector
+	pod.Spec.Tolerations = tolerations
+	pod.Spec.PriorityClassName = "placeholder-runner"
+	return pod
+}
+
+// buildWorkflowPlaceholder constructs a placeholder pod that mirrors the
+// workflow/job pod spec defined in modules/arc-runners/templates/runner.yaml.tpl
+// (the `job-pod.yaml:` section inside the ConfigMap). Specs MUST stay in
+// sync with that template.
+func (pm *PlaceholderManager) buildWorkflowPlaceholder(slotID string) *corev1.Pod {
+	name := truncatePodName(fmt.Sprintf("ph-w-%s-%s", pm.config.ScaleSetName, slotID))
+
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+	pm.setQuantity(&resources, corev1.ResourceCPU, pm.config.WorkflowCPU, "WorkflowCPU")
+	pm.setQuantity(&resources, corev1.ResourceMemory, pm.config.WorkflowMemory, "WorkflowMemory")
+	pm.setQuantity(&resources, corev1.ResourceEphemeralStorage, pm.config.WorkflowDisk, "WorkflowDisk")
+	if pm.config.WorkflowGPU > 0 {
+		// GPU count is an int — formatted as a plain integer string,
+		// which is always valid for a resource.Quantity, so safe to parse.
+		pm.setQuantity(&resources, "nvidia.com/gpu",
+			strconv.Itoa(pm.config.WorkflowGPU), "WorkflowGPU")
+	}
+
+	// Workflow tolerations: node-fleet, instance-type Exists, optional GPU.
+	// NO git-cache-not-ready (matches template — workflow waits for cache).
+	tolerations := []corev1.Toleration{
+		{
+			Key:      "instance-type",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	if pm.config.NodeFleet != "" {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "node-fleet",
+			Operator: corev1.TolerationOpEqual,
+			Value:    pm.config.NodeFleet,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+	if pm.config.WorkflowGPU > 0 {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      "nvidia.com/gpu",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+
+	pod := pm.placeholderPodShell(name, slotID, rolePlaceholderWorkflow, resources)
+	// Workflow pods use soft affinity (preferredDuringScheduling), no hard nodeSelector.
+	pod.Spec.Affinity = pm.buildWorkflowAffinity()
+	pod.Spec.Tolerations = tolerations
+	pod.Spec.PriorityClassName = "placeholder-workflow"
+	return pod
+}
+
+// buildWorkflowAffinity builds the soft node affinity for workflow placeholders,
+// mirroring the job-pod template:
+//   - weight 50 preference for node-fleet + workload-type
+//   - optional weight 100 preference for runner-class (when set)
+//   - optional GPU node selector requirement (when WorkflowGPU > 0)
+func (pm *PlaceholderManager) buildWorkflowAffinity() *corev1.Affinity {
+	preferredTerms := []corev1.PreferredSchedulingTerm{}
+
+	// Optional runner-class preference (template uses higher weight for class match).
+	if pm.config.RunnerClass != "" {
+		preferredTerms = append(preferredTerms, corev1.PreferredSchedulingTerm{
+			Weight: 100,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "osdc.io/runner-class",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{pm.config.RunnerClass},
+					},
+				},
+			},
+		})
+	}
+
+	// Same-fleet preference (always present, weight 50 per template).
+	fleetMatchExpressions := []corev1.NodeSelectorRequirement{
+		{
+			Key:      "workload-type",
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"github-runner"},
+		},
+	}
+	if pm.config.NodeFleet != "" {
+		fleetMatchExpressions = append([]corev1.NodeSelectorRequirement{
+			{
+				Key:      "node-fleet",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{pm.config.NodeFleet},
+			},
+		}, fleetMatchExpressions...)
+	}
+	preferredTerms = append(preferredTerms, corev1.PreferredSchedulingTerm{
+		Weight: 50,
+		Preference: corev1.NodeSelectorTerm{
+			MatchExpressions: fleetMatchExpressions,
+		},
+	})
+
+	affinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: preferredTerms,
+		},
+	}
+
+	// Optional hard GPU node selector requirement.
+	if pm.config.WorkflowGPU > 0 {
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "nvidia.com/gpu.present",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return affinity
+}
+
+// placeholderPodShell returns a Pod with metadata, labels, and a single
+// sleep container. Caller is responsible for setting NodeSelector,
+// Tolerations, Affinity, and PriorityClassName as appropriate.
+func (pm *PlaceholderManager) placeholderPodShell(
+	name, slotID, role string,
+	resources corev1.ResourceRequirements,
+) *corev1.Pod {
+	var zero int64
+	labels := map[string]string{
+		labelManagedBy:       managedByValue,
+		labelScaleSet:        pm.config.ScaleSetName,
+		labelPlaceholderID:   slotID,
+		labelPlaceholderRole: role,
+		labelListenerPod:     pm.listenerID,
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: pm.namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"karpenter.sh/do-not-disrupt": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:      "placeholder",
+					Image:     placeholderImage,
+					Command:   []string{"sleep", "infinity"},
+					Resources: resources,
+				},
+			},
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: &zero,
+		},
+	}
+}
+
+// ---- helpers ----
+
+func groupBySlot(pods []corev1.Pod) map[string]*PlaceholderPair {
+	pairs := make(map[string]*PlaceholderPair)
+	for i := range pods {
+		pod := &pods[i]
+		slotID := pod.Labels[labelPlaceholderID]
+		if slotID == "" {
+			continue
+		}
+		pair, ok := pairs[slotID]
+		if !ok {
+			pair = &PlaceholderPair{
+				SlotID:    slotID,
+				CreatedAt: pod.CreationTimestamp.Time,
+			}
+			pairs[slotID] = pair
+		}
+		if pod.CreationTimestamp.Time.Before(pair.CreatedAt) {
+			pair.CreatedAt = pod.CreationTimestamp.Time
+		}
+		switch pod.Labels[labelPlaceholderRole] {
+		case rolePlaceholderRunner:
+			pair.RunnerPod = pod
+		case rolePlaceholderWorkflow:
+			pair.WorkflowPod = pod
+		}
+	}
+	return pairs
+}
+
+// truncatePodName ensures the name fits the K8s 63-char pod name limit.
+// When truncation is needed, it appends an 8-char sha256 hex suffix of
+// the original name to preserve uniqueness across collisions.
+func truncatePodName(name string) string {
+	if len(name) <= maxPodNameLen {
+		return name
+	}
+	hash := sha256.Sum256([]byte(name))
+	suffix := hex.EncodeToString(hash[:4]) // 8 hex chars
+	return name[:maxPodNameLen-9] + "-" + suffix
+}

--- a/cmd/ghalistener/capacity/placeholder_test.go
+++ b/cmd/ghalistener/capacity/placeholder_test.go
@@ -1,0 +1,388 @@
+package capacity
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var discardLogger = slog.New(slog.DiscardHandler)
+
+// newFakeClientset creates a fake.Clientset with a reactor that makes
+// DeleteCollection actually delete matching pods from the object tracker.
+// The default fake client records the action but does not remove objects.
+func newFakeClientset() *fake.Clientset {
+	cs := fake.NewSimpleClientset()
+	podsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	podsGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+
+	// The default fake client's DeleteCollection records the action but
+	// does not actually remove objects from the tracker. This reactor
+	// uses the ObjectTracker directly (bypassing Invokes) to avoid the
+	// mutex deadlock that would occur if we called cs.CoreV1().Pods()
+	// from within a reactor.
+	cs.PrependReactor("delete-collection", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			dca := action.(k8stesting.DeleteCollectionActionImpl)
+			ns := dca.GetNamespace()
+			selectorStr := dca.GetListOptions().LabelSelector
+
+			obj, err := cs.Tracker().List(podsGVR, podsGVK, ns)
+			if err != nil {
+				return true, nil, err
+			}
+			podList := obj.(*corev1.PodList)
+
+			sel, err := labels.Parse(selectorStr)
+			if err != nil {
+				return true, nil, err
+			}
+
+			for i := range podList.Items {
+				p := &podList.Items[i]
+				if sel.Matches(labels.Set(p.Labels)) {
+					_ = cs.Tracker().Delete(podsGVR, ns, p.Name)
+				}
+			}
+			return true, nil, nil
+		},
+	)
+	return cs
+}
+
+func newTestPM(t *testing.T, cfg Config) (*PlaceholderManager, *fake.Clientset) {
+	t.Helper()
+	if cfg.Namespace == "" {
+		cfg.Namespace = "test-ns"
+	}
+	if cfg.ScaleSetName == "" {
+		cfg.ScaleSetName = "test-scale-set"
+	}
+	cs := newFakeClientset()
+	pm := NewPlaceholderManager(cs, cfg.Namespace, "listener-abc", cfg, discardLogger)
+	return pm, cs
+}
+
+func TestCreatePair(t *testing.T) {
+	cfg := Config{
+		RunnerCPU:      "750m",
+		RunnerMemory:   "512Mi",
+		WorkflowCPU:    "4",
+		WorkflowMemory: "8Gi",
+	}
+	pm, cs := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	err := pm.CreatePair(ctx, "slot-1")
+	require.NoError(t, err)
+
+	pods, err := cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, pods.Items, 2)
+
+	var runner, workflow *corev1.Pod
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		switch p.Labels[labelPlaceholderRole] {
+		case rolePlaceholderRunner:
+			runner = p
+		case rolePlaceholderWorkflow:
+			workflow = p
+		}
+	}
+	require.NotNil(t, runner, "runner pod must exist")
+	require.NotNil(t, workflow, "workflow pod must exist")
+
+	// Names.
+	assert.True(t, strings.HasPrefix(runner.Name, "ph-r-"), "runner name prefix")
+	assert.True(t, strings.HasPrefix(workflow.Name, "ph-w-"), "workflow name prefix")
+
+	// Labels.
+	assert.Equal(t, managedByValue, runner.Labels[labelManagedBy])
+	assert.Equal(t, "slot-1", runner.Labels[labelPlaceholderID])
+	assert.Equal(t, "listener-abc", runner.Labels[labelListenerPod])
+	assert.Equal(t, "test-scale-set", runner.Labels[labelScaleSet])
+
+	// Priority classes.
+	assert.Equal(t, "placeholder-runner", runner.Spec.PriorityClassName)
+	assert.Equal(t, "placeholder-workflow", workflow.Spec.PriorityClassName)
+
+	// Runner uses hard nodeSelector; workflow uses soft node affinity
+	// (matching modules/arc-runners/templates/runner.yaml.tpl).
+	assert.Nil(t, runner.Spec.Affinity, "runner uses nodeSelector, not affinity")
+	assert.Nil(t, workflow.Spec.NodeSelector,
+		"workflow uses affinity, not hard nodeSelector")
+	require.NotNil(t, workflow.Spec.Affinity, "workflow must have affinity")
+	require.NotNil(t, workflow.Spec.Affinity.NodeAffinity, "workflow nodeAffinity")
+
+	// Resources.
+	runnerReq := runner.Spec.Containers[0].Resources.Requests
+	assert.Equal(t, "750m", runnerReq.Cpu().String())
+	assert.Equal(t, "512Mi", runnerReq.Memory().String())
+
+	wfReq := workflow.Spec.Containers[0].Resources.Requests
+	assert.Equal(t, "4", wfReq.Cpu().String())
+	assert.Equal(t, "8Gi", wfReq.Memory().String())
+}
+
+// When the workflow pod creation fails, the runner pod that was already
+// created must be best-effort cleaned up so we don't leave a half-pair
+// occupying capacity.
+func TestCreatePair_WorkflowFailureCleansUpRunner(t *testing.T) {
+	pm, cs := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	// Inject a failure for the workflow pod create only (name has "ph-w-" prefix).
+	cs.PrependReactor("create", "pods",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			ca := action.(k8stesting.CreateAction)
+			pod, ok := ca.GetObject().(*corev1.Pod)
+			if !ok {
+				return false, nil, nil
+			}
+			if strings.HasPrefix(pod.Name, "ph-w-") {
+				return true, nil, errors.New("simulated workflow create failure")
+			}
+			return false, nil, nil
+		},
+	)
+
+	err := pm.CreatePair(ctx, "fail-slot")
+	require.Error(t, err, "CreatePair must surface workflow creation error")
+	assert.Contains(t, err.Error(), "creating workflow placeholder")
+
+	// Runner pod must have been best-effort deleted; no pods should remain.
+	pods, listErr := cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, pods.Items,
+		"runner pod must be cleaned up after workflow create failure")
+}
+
+func TestDeletePair(t *testing.T) {
+	pm, cs := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "slot-del"))
+
+	pods, _ := cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	require.Len(t, pods.Items, 2)
+
+	require.NoError(t, pm.DeletePair(ctx, "slot-del"))
+
+	pods, _ = cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	assert.Empty(t, pods.Items)
+}
+
+func TestListPairs_GroupsBySlotID(t *testing.T) {
+	pm, _ := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "slot-a"))
+	require.NoError(t, pm.CreatePair(ctx, "slot-b"))
+
+	pairs, err := pm.ListPairs(ctx)
+	require.NoError(t, err)
+	assert.Len(t, pairs, 2)
+	assert.Contains(t, pairs, "slot-a")
+	assert.Contains(t, pairs, "slot-b")
+
+	for _, pair := range pairs {
+		assert.NotNil(t, pair.RunnerPod, "pair must have runner pod")
+		assert.NotNil(t, pair.WorkflowPod, "pair must have workflow pod")
+	}
+}
+
+func TestCleanupTimedOut(t *testing.T) {
+	cfg := Config{PlaceholderTimeout: 1 * time.Second}
+	pm, cs := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "slot-old"))
+	require.NoError(t, pm.CreatePair(ctx, "slot-new"))
+
+	// Make "old" pair's pods Pending with old creation timestamps.
+	setPodsCreationAndPhase(t, cs, ctx, "test-ns", "slot-old",
+		time.Now().Add(-10*time.Minute), corev1.PodPending)
+	// Make "new" pair's pods Pending but recent.
+	setPodsCreationAndPhase(t, cs, ctx, "test-ns", "slot-new",
+		time.Now(), corev1.PodPending)
+
+	deleted, err := pm.CleanupTimedOut(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+
+	pairs, _ := pm.ListPairs(ctx)
+	assert.Len(t, pairs, 1)
+	assert.Contains(t, pairs, "slot-new")
+}
+
+func TestCleanupOrphans(t *testing.T) {
+	cfg := Config{Namespace: "test-ns", ScaleSetName: "sset"}
+	cs := newFakeClientset()
+	ctx := context.Background()
+
+	// Create pods from a different listener (same scale set) — these are orphans.
+	otherPM := NewPlaceholderManager(cs, "test-ns", "old-listener", cfg, discardLogger)
+	require.NoError(t, otherPM.CreatePair(ctx, "orphan-slot"))
+
+	// Create pods from the current listener.
+	pm := NewPlaceholderManager(cs, "test-ns", "current-listener", cfg, discardLogger)
+	require.NoError(t, pm.CreatePair(ctx, "my-slot"))
+
+	pods, _ := cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	assert.Len(t, pods.Items, 4, "4 pods before cleanup")
+
+	require.NoError(t, pm.CleanupOrphans(ctx))
+
+	pods, _ = cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	assert.Len(t, pods.Items, 2, "only current listener pods remain")
+	for _, p := range pods.Items {
+		assert.Equal(t, "current-listener", p.Labels[labelListenerPod])
+	}
+}
+
+// CleanupOrphans must only delete pods belonging to the SAME scale set —
+// listeners from a different scale set must be left alone.
+// Regression test for the cross-scale-set deletion bug.
+func TestCleanupOrphans_ScopedToScaleSet(t *testing.T) {
+	cs := newFakeClientset()
+	ctx := context.Background()
+
+	// Other scale set, other listener — must NOT be touched.
+	otherSetCfg := Config{Namespace: "test-ns", ScaleSetName: "other-sset"}
+	otherSetPM := NewPlaceholderManager(cs, "test-ns", "old-listener-other-sset", otherSetCfg, discardLogger)
+	require.NoError(t, otherSetPM.CreatePair(ctx, "other-slot"))
+
+	// Same scale set, different listener — orphan, MUST be deleted.
+	myCfg := Config{Namespace: "test-ns", ScaleSetName: "my-sset"}
+	stalePM := NewPlaceholderManager(cs, "test-ns", "old-listener-my-sset", myCfg, discardLogger)
+	require.NoError(t, stalePM.CreatePair(ctx, "stale-slot"))
+
+	// Same scale set, current listener — MUST be left alone.
+	pm := NewPlaceholderManager(cs, "test-ns", "current-listener", myCfg, discardLogger)
+	require.NoError(t, pm.CreatePair(ctx, "current-slot"))
+
+	pods, _ := cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	assert.Len(t, pods.Items, 6, "6 pods before cleanup")
+
+	require.NoError(t, pm.CleanupOrphans(ctx))
+
+	pods, _ = cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	// 2 from other-sset (preserved) + 2 from current listener (preserved).
+	assert.Len(t, pods.Items, 4,
+		"orphan pods from same scale set deleted; other scale set untouched")
+
+	otherSetCount, currentCount, staleCount := 0, 0, 0
+	for _, p := range pods.Items {
+		switch p.Labels[labelScaleSet] {
+		case "other-sset":
+			otherSetCount++
+		case "my-sset":
+			if p.Labels[labelListenerPod] == "current-listener" {
+				currentCount++
+			} else {
+				staleCount++
+			}
+		}
+	}
+	assert.Equal(t, 2, otherSetCount, "other scale set pods preserved")
+	assert.Equal(t, 2, currentCount, "current listener pods preserved")
+	assert.Equal(t, 0, staleCount, "stale orphans of same scale set deleted")
+}
+
+func TestCleanupAll(t *testing.T) {
+	pm, cs := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "s1"))
+	require.NoError(t, pm.CreatePair(ctx, "s2"))
+
+	pods, _ := cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	assert.Len(t, pods.Items, 4)
+
+	require.NoError(t, pm.CleanupAll(ctx))
+
+	pods, _ = cs.CoreV1().Pods("test-ns").List(ctx, metav1.ListOptions{})
+	assert.Empty(t, pods.Items)
+}
+
+func TestBothRunning(t *testing.T) {
+	pair := &PlaceholderPair{
+		RunnerPod:   &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+		WorkflowPod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}},
+	}
+	assert.True(t, pair.BothRunning())
+
+	pair.WorkflowPod.Status.Phase = corev1.PodPending
+	assert.False(t, pair.BothRunning())
+
+	pair.WorkflowPod = nil
+	assert.False(t, pair.BothRunning())
+}
+
+func TestAnyPendingTooLong(t *testing.T) {
+	timeout := 5 * time.Minute
+	oldTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	recentTime := metav1.NewTime(time.Now())
+
+	pair := &PlaceholderPair{
+		RunnerPod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: oldTime},
+			Status:     corev1.PodStatus{Phase: corev1.PodPending},
+		},
+		WorkflowPod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: recentTime},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	}
+	assert.True(t, pair.AnyPendingTooLong(timeout), "old pending runner triggers")
+
+	pair.RunnerPod.Status.Phase = corev1.PodRunning
+	assert.False(t, pair.AnyPendingTooLong(timeout), "running pods do not trigger")
+}
+
+// ---- test helpers ----
+
+func setPodsPhase(t *testing.T, cs *fake.Clientset, ctx context.Context,
+	ns, slotID string, phase corev1.PodPhase) {
+	t.Helper()
+	pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labelPlaceholderID + "=" + slotID,
+	})
+	require.NoError(t, err)
+	for i := range pods.Items {
+		p := pods.Items[i]
+		p.Status.Phase = phase
+		_, err := cs.CoreV1().Pods(ns).UpdateStatus(ctx, &p, metav1.UpdateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+func setPodsCreationAndPhase(t *testing.T, cs *fake.Clientset, ctx context.Context,
+	ns, slotID string, created time.Time, phase corev1.PodPhase) {
+	t.Helper()
+	podsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: labelPlaceholderID + "=" + slotID,
+	})
+	require.NoError(t, err)
+	for i := range pods.Items {
+		p := pods.Items[i]
+		p.CreationTimestamp = metav1.NewTime(created)
+		p.Status.Phase = phase
+		require.NoError(t, cs.Tracker().Update(podsGVR, &p, ns))
+	}
+}

--- a/cmd/ghalistener/capacity/pod_spec_test.go
+++ b/cmd/ghalistener/capacity/pod_spec_test.go
@@ -1,0 +1,296 @@
+package capacity
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPodNameTruncation(t *testing.T) {
+	longName := strings.Repeat("a", 100)
+	result := truncatePodName(longName)
+	assert.Len(t, result, maxPodNameLen)
+
+	shortName := "ph-r-test-slot1"
+	assert.Equal(t, shortName, truncatePodName(shortName))
+}
+
+// Runner placeholder mirrors the runner.yaml.tpl template's `template:`
+// section: hard nodeSelector with workload-type, optional node-fleet,
+// optional runner-class. Tolerations: instance-type Exists, git-cache,
+// optional node-fleet, optional GPU, optional runner-class. NO
+// workload-type toleration (it's a node label, not a taint).
+func TestRunnerPlaceholder_NoGPU_NoFleet_NoRunnerClass(t *testing.T) {
+	pm, _ := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "s1"))
+	pairs, _ := pm.ListPairs(ctx)
+	runner := pairs["s1"].RunnerPod
+
+	assert.Equal(t, "github-runner", runner.Spec.NodeSelector["workload-type"])
+	_, hasFleet := runner.Spec.NodeSelector["node-fleet"]
+	assert.False(t, hasFleet, "no node-fleet without NodeFleet config")
+	_, hasRC := runner.Spec.NodeSelector["osdc.io/runner-class"]
+	assert.False(t, hasRC, "no runner-class without RunnerClass config")
+
+	// Without NodeFleet/GPU/RunnerClass: only instance-type + git-cache-not-ready.
+	assert.Len(t, runner.Spec.Tolerations, 2)
+	tolerationKeys := tolerationKeySet(runner.Spec.Tolerations)
+	assert.Contains(t, tolerationKeys, "instance-type")
+	assert.Contains(t, tolerationKeys, "git-cache-not-ready")
+}
+
+// Workflow placeholder mirrors the job-pod.yaml ConfigMap template:
+// NO hard nodeSelector — uses preferredDuringScheduling node affinity
+// with weight 50 for node-fleet + workload-type. Tolerations:
+// instance-type Exists, optional node-fleet, optional GPU. NO
+// git-cache-not-ready (workflow waits for cache, doesn't tolerate the taint).
+func TestWorkflowPlaceholder_NoGPU_NoFleet_NoRunnerClass(t *testing.T) {
+	pm, _ := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "s1"))
+	pairs, _ := pm.ListPairs(ctx)
+	wf := pairs["s1"].WorkflowPod
+
+	assert.Nil(t, wf.Spec.NodeSelector, "workflow has no hard nodeSelector")
+
+	require.NotNil(t, wf.Spec.Affinity)
+	require.NotNil(t, wf.Spec.Affinity.NodeAffinity)
+	preferred := wf.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.NotEmpty(t, preferred)
+	assert.Equal(t, int32(50), preferred[len(preferred)-1].Weight)
+
+	// Without NodeFleet/GPU: only instance-type toleration. No git-cache.
+	assert.Len(t, wf.Spec.Tolerations, 1)
+	assert.Equal(t, "instance-type", wf.Spec.Tolerations[0].Key)
+	for _, tol := range wf.Spec.Tolerations {
+		assert.NotEqual(t, "git-cache-not-ready", tol.Key,
+			"workflow must not tolerate git-cache-not-ready")
+	}
+}
+
+func TestRunnerPlaceholder_WithGPU_WithFleet_WithRunnerClass(t *testing.T) {
+	cfg := Config{
+		WorkflowGPU: 2,
+		NodeFleet:   "gpu-fleet",
+		RunnerClass: "gpu-large",
+	}
+	pm, _ := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "gpu-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+	runner := pairs["gpu-slot"].RunnerPod
+
+	// Runner has hard nodeSelector for fleet + class.
+	assert.Equal(t, "gpu-fleet", runner.Spec.NodeSelector["node-fleet"])
+	assert.Equal(t, "gpu-large", runner.Spec.NodeSelector["osdc.io/runner-class"])
+	assert.Equal(t, "github-runner", runner.Spec.NodeSelector["workload-type"])
+
+	// instance-type + git-cache-not-ready + node-fleet + GPU + runner-class = 5.
+	assert.Len(t, runner.Spec.Tolerations, 5)
+	keys := tolerationKeySet(runner.Spec.Tolerations)
+	assert.Contains(t, keys, "instance-type")
+	assert.Contains(t, keys, "git-cache-not-ready")
+	assert.Contains(t, keys, "node-fleet")
+	assert.Contains(t, keys, "nvidia.com/gpu")
+	assert.Contains(t, keys, "osdc.io/runner-class")
+
+	// GPU toleration uses Exists operator (template uses Exists).
+	for _, tol := range runner.Spec.Tolerations {
+		if tol.Key == "nvidia.com/gpu" {
+			assert.Equal(t, corev1.TolerationOpExists, tol.Operator)
+		}
+	}
+}
+
+func TestWorkflowPlaceholder_WithGPU_WithFleet_WithRunnerClass(t *testing.T) {
+	cfg := Config{
+		WorkflowGPU: 2,
+		NodeFleet:   "gpu-fleet",
+		RunnerClass: "gpu-large",
+		WorkflowCPU: "4",
+	}
+	pm, _ := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "gpu-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+	wf := pairs["gpu-slot"].WorkflowPod
+
+	// Workflow has no hard nodeSelector regardless of config.
+	assert.Nil(t, wf.Spec.NodeSelector)
+
+	// Affinity: required GPU node selector + preferred runner-class + preferred fleet.
+	require.NotNil(t, wf.Spec.Affinity)
+	require.NotNil(t, wf.Spec.Affinity.NodeAffinity)
+	preferred := wf.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	assert.Len(t, preferred, 2, "runner-class preference + fleet preference")
+	require.NotNil(t, wf.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+		"GPU workflow has required GPU node selector")
+
+	// Tolerations: instance-type + node-fleet + GPU = 3.
+	assert.Len(t, wf.Spec.Tolerations, 3)
+	keys := tolerationKeySet(wf.Spec.Tolerations)
+	assert.Contains(t, keys, "instance-type")
+	assert.Contains(t, keys, "node-fleet")
+	assert.Contains(t, keys, "nvidia.com/gpu")
+	assert.NotContains(t, keys, "git-cache-not-ready",
+		"workflow must not tolerate git-cache-not-ready")
+
+	// Verify GPU resources on workflow pod.
+	gpuReq := wf.Spec.Containers[0].Resources.Requests["nvidia.com/gpu"]
+	assert.Equal(t, "2", gpuReq.String())
+	gpuLim := wf.Spec.Containers[0].Resources.Limits["nvidia.com/gpu"]
+	assert.Equal(t, "2", gpuLim.String())
+}
+
+func TestWorkflowDiskResource(t *testing.T) {
+	cfg := Config{WorkflowDisk: "200Gi"}
+	pm, _ := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "disk-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+	wf := pairs["disk-slot"].WorkflowPod
+	diskReq := wf.Spec.Containers[0].Resources.Requests[corev1.ResourceEphemeralStorage]
+	assert.Equal(t, "200Gi", diskReq.String())
+	diskLim := wf.Spec.Containers[0].Resources.Limits[corev1.ResourceEphemeralStorage]
+	assert.Equal(t, "200Gi", diskLim.String(),
+		"setQuantity must mirror Requests into Limits")
+}
+
+// Both placeholder pods must carry karpenter.sh/do-not-disrupt=true so
+// Karpenter does not consolidate the pre-warmed nodes out from under us.
+func TestPlaceholderPods_KarpenterDoNotDisruptAnnotation(t *testing.T) {
+	pm, _ := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "ann-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+	pair := pairs["ann-slot"]
+
+	for _, pod := range []*corev1.Pod{pair.RunnerPod, pair.WorkflowPod} {
+		require.NotNil(t, pod)
+		assert.Equal(t, "true", pod.Annotations["karpenter.sh/do-not-disrupt"],
+			"placeholder pods must opt out of Karpenter consolidation")
+	}
+}
+
+// Both placeholder containers must run `sleep infinity` (not `sleep 900`).
+// A finite sleep would let the placeholder exit and free the node, defeating
+// the purpose of pre-warming.
+func TestPlaceholderPods_SleepInfinityCommand(t *testing.T) {
+	pm, _ := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "cmd-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+	pair := pairs["cmd-slot"]
+
+	for _, pod := range []*corev1.Pod{pair.RunnerPod, pair.WorkflowPod} {
+		require.NotNil(t, pod)
+		require.Len(t, pod.Spec.Containers, 1)
+		assert.Equal(t, []string{"sleep", "infinity"}, pod.Spec.Containers[0].Command)
+	}
+}
+
+// setQuantity must mirror every parsed Request into Limits (equal request/limit
+// is the contract documented on the helper). Verify on the runner pod where
+// CPU and memory both come from setQuantity.
+func TestRunnerPlaceholder_RequestsEqualLimits(t *testing.T) {
+	cfg := Config{RunnerCPU: "750m", RunnerMemory: "512Mi"}
+	pm, _ := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "eq-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+	runner := pairs["eq-slot"].RunnerPod
+
+	res := runner.Spec.Containers[0].Resources
+	assert.Equal(t, res.Requests.Cpu().String(), res.Limits.Cpu().String(),
+		"runner CPU request and limit must match")
+	assert.Equal(t, res.Requests.Memory().String(), res.Limits.Memory().String(),
+		"runner memory request and limit must match")
+}
+
+// Empty resource strings must be skipped (not parsed) so the resulting
+// pod has no Requests/Limits entry for that resource. Regression coverage
+// for the setQuantity early-return on empty input.
+func TestSetQuantity_EmptyValueOmitsResource(t *testing.T) {
+	// All resource strings empty → no Requests / Limits keys set.
+	pm, _ := newTestPM(t, Config{})
+	ctx := context.Background()
+
+	require.NoError(t, pm.CreatePair(ctx, "empty-slot"))
+	pairs, _ := pm.ListPairs(ctx)
+
+	wf := pairs["empty-slot"].WorkflowPod
+	assert.Empty(t, wf.Spec.Containers[0].Resources.Requests,
+		"empty workflow resource strings must produce no Requests entries")
+	assert.Empty(t, wf.Spec.Containers[0].Resources.Limits,
+		"empty workflow resource strings must produce no Limits entries")
+}
+
+// An invalid resource quantity must be skipped, not panic. Production code
+// switched from resource.MustParse → resource.ParseQuantity precisely to
+// degrade gracefully on bad operator input.
+func TestSetQuantity_InvalidValueSkippedNotPanic(t *testing.T) {
+	cfg := Config{RunnerCPU: "not-a-quantity", RunnerMemory: "512Mi"}
+	pm, _ := newTestPM(t, cfg)
+	ctx := context.Background()
+
+	require.NotPanics(t, func() {
+		_ = pm.CreatePair(ctx, "bad-slot")
+	})
+
+	pairs, _ := pm.ListPairs(ctx)
+	runner := pairs["bad-slot"].RunnerPod
+	res := runner.Spec.Containers[0].Resources
+	_, hasCPUReq := res.Requests[corev1.ResourceCPU]
+	_, hasCPULim := res.Limits[corev1.ResourceCPU]
+	assert.False(t, hasCPUReq, "invalid CPU value must not produce a Requests entry")
+	assert.False(t, hasCPULim, "invalid CPU value must not produce a Limits entry")
+	// Memory is still set (valid value).
+	assert.Equal(t, "512Mi", res.Requests.Memory().String())
+}
+
+// truncatePodName must (a) yield a name within the 63-char limit, (b) preserve
+// uniqueness across long names that share a prefix via a sha256 hex suffix,
+// and (c) produce names that are still valid DNS-1123 subdomains.
+func TestPodNameTruncation_HashSuffixPreservesUniqueness(t *testing.T) {
+	long1 := "ph-r-" + strings.Repeat("x", 80) + "-aaa"
+	long2 := "ph-r-" + strings.Repeat("x", 80) + "-bbb"
+
+	got1 := truncatePodName(long1)
+	got2 := truncatePodName(long2)
+
+	assert.Len(t, got1, maxPodNameLen)
+	assert.Len(t, got2, maxPodNameLen)
+	assert.NotEqual(t, got1, got2,
+		"distinct long names must produce distinct truncated names via hash suffix")
+
+	// The suffix is `-` plus 8 hex chars (8 = 4 bytes hex-encoded).
+	const suffixLen = 9
+	suffix1 := got1[len(got1)-suffixLen:]
+	assert.Equal(t, "-", suffix1[:1])
+	for _, c := range suffix1[1:] {
+		assert.True(t,
+			(c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+			"truncated suffix must be lower-case hex, got %q", suffix1)
+	}
+}
+
+func tolerationKeySet(tolerations []corev1.Toleration) map[string]struct{} {
+	s := make(map[string]struct{}, len(tolerations))
+	for _, t := range tolerations {
+		s[t.Key] = struct{}{}
+	}
+	return s
+}

--- a/cmd/ghalistener/main.go
+++ b/cmd/ghalistener/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/actions/actions-runner-controller/cmd/ghalistener/capacity"
 	"github.com/actions/actions-runner-controller/cmd/ghalistener/config"
 	"github.com/actions/actions-runner-controller/cmd/ghalistener/metrics"
 	"github.com/actions/actions-runner-controller/cmd/ghalistener/scaler"
@@ -15,6 +16,8 @@ import (
 	"github.com/actions/scaleset/listener"
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func main() {
@@ -125,6 +128,65 @@ func run(ctx context.Context, config *config.Config) error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create new kubernetes worker: %w", err)
+	}
+
+	// Capacity monitor (optional).
+	capConfig := capacity.ConfigFromEnv()
+	if capConfig.Enabled {
+		scaleSet, err := scalesetClient.GetRunnerScaleSetByID(ctx, config.RunnerScaleSetID)
+		if err != nil {
+			return fmt.Errorf("failed to get scale set for capacity monitor: %w", err)
+		}
+		var labels []string
+		for _, l := range scaleSet.Labels {
+			labels = append(labels, l.Name)
+		}
+
+		capConfig.MaxRunners = config.MaxRunners
+		capConfig.ScaleSetID = config.RunnerScaleSetID
+		capConfig.ScaleSetLabels = labels
+		capConfig.Namespace = config.EphemeralRunnerSetNamespace
+		capConfig.ScaleSetName = config.RunnerScaleSetName
+
+		k8sConf, err := rest.InClusterConfig()
+		if err != nil {
+			return fmt.Errorf("failed to create k8s config for capacity monitor: %w", err)
+		}
+		k8sClient, err := kubernetes.NewForConfig(k8sConf)
+		if err != nil {
+			return fmt.Errorf("failed to create k8s client for capacity monitor: %w", err)
+		}
+
+		capMonitor := capacity.New(capConfig, k8sClient, listener.SetMaxRunners, logger)
+		logger.Info("Capacity monitor enabled",
+			"proactiveCapacity", capConfig.ProactiveCapacity,
+			"nodeFleet", capConfig.NodeFleet,
+			"runnerClass", capConfig.RunnerClass,
+		)
+
+		g, ctx := errgroup.WithContext(ctx)
+		metricsCtx, cancelMetrics := context.WithCancelCause(ctx)
+
+		g.Go(func() error {
+			logger.Info("Starting listener")
+			listnerErr := listener.Run(ctx, scaler)
+			cancelMetrics(fmt.Errorf("listener exited: %w", listnerErr))
+			return listnerErr
+		})
+
+		g.Go(func() error {
+			logger.Info("Starting capacity monitor")
+			return capMonitor.Run(ctx)
+		})
+
+		if metricsExporter != nil {
+			g.Go(func() error {
+				logger.Info("Starting metrics server")
+				return metricsExporter.ListenAndServe(metricsCtx)
+			})
+		}
+
+		return g.Wait()
 	}
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
**Impact:** PyTorch CI runner infrastructure — affects runner queue latency for all scale sets that opt in via `CAPACITY_AWARE_ENABLED=true`
**Risk:** low (opt-in via env var, disabled by default, no changes to existing listener/scaler codepaths)

## What
Adds an optional capacity monitor to the GHA listener that pre-warms Kubernetes nodes by creating lightweight placeholder pod pairs (runner + workflow), sized to match real runner specs. The monitor also queries the PyTorch HUD API for queued job counts and dynamically adjusts the `maxRunners` value reported to GitHub so that nodes are ready before jobs arrive.

## Why
GitHub Actions runners on Kubernetes suffer cold-start latency when new nodes must be provisioned by Karpenter. By deploying placeholder pods that claim the same resources (CPU, memory, GPU, ephemeral storage) and target the same node selectors/tolerations as real runners, Karpenter pre-provisions nodes ahead of demand. When a real job arrives, the placeholder is evicted (via lower PriorityClass) and the runner lands on the already-warm node. See https://github.com/pytorch/ci-infra/issues/499 for the full design.

## How
- Placeholder pods are created in **pairs** (runner + workflow) to mirror the actual two-pod-per-job architecture. Each pair reserves one node's worth of capacity.
- Pod specs are built programmatically to match the Helm templates in `modules/arc-runners/templates/runner.yaml.tpl` — same nodeSelectors, tolerations, affinities, resource requests/limits, and Karpenter annotations (`karpenter.sh/do-not-disrupt: true`).
- The reconcile loop runs on a configurable interval (default 30s): query HUD for queue depth, garbage-collect timed-out placeholders, adjust pair count to `proactiveCapacity + queuedJobs` (capped at `maxRunners`), and report capacity to GitHub.
- Scale-down prefers deleting Pending pairs over Running ones to preserve already-warmed nodes.
- Orphan cleanup on startup scopes to the same scale set to avoid cross-listener interference.
- `MaxRunners == 0` is treated as "unlimited" (not "zero capacity") to match upstream ARC semantics.

## Changes
- **New package `cmd/ghalistener/capacity/`** with four source files:
  - `config.go` — env-based configuration with validation, hard cap (1000), and warn threshold (100)
  - `hud_client.go` — HTTP client for `hud.pytorch.org/api/clickhouse/queued_jobs_aggregate` with 10 MiB response cap
  - `placeholder.go` — `PlaceholderManager` for CRUD on placeholder pod pairs via K8s API, pod spec builders with node placement logic
  - `monitor.go` — reconcile loop, HUD integration, capacity reporting via `listener.SetMaxRunners`
- **`cmd/ghalistener/main.go`** — conditionally starts the capacity monitor goroutine alongside the listener when `CAPACITY_AWARE_ENABLED=true`; adds `k8s.io/client-go` imports for in-cluster config
- **`.gitignore`** — adds `ghalistener` binary

## Notes
- The feature is **entirely opt-in**: `CAPACITY_AWARE_ENABLED` defaults to `false`. Existing deployments are unaffected.
- Placeholder pod specs must stay in sync with the Helm templates (`runner.yaml.tpl`). Comments in the code call this out explicitly.
- The HUD API integration gracefully degrades — on any error, `queuedJobs` falls back to 0 and only `proactiveCapacity` drives placeholder count.
- Two new PriorityClasses (`placeholder-runner`, `placeholder-workflow`) must exist in the cluster before enabling. These should be lower priority than real runner pods so Kubernetes evicts placeholders when real jobs arrive.
- Environment variables for configuration:
  - `CAPACITY_AWARE_ENABLED` — enable/disable (default: `false`)
  - `CAPACITY_AWARE_PROACTIVE_CAPACITY` — base placeholder count (default: `0`)
  - `CAPACITY_AWARE_RECALCULATE_INTERVAL` — reconcile period (default: `30s`)
  - `CAPACITY_AWARE_PLACEHOLDER_TIMEOUT` — max Pending time before cleanup (default: `5m`)
  - `CAPACITY_AWARE_WORKFLOW_CPU/MEMORY/GPU/DISK` — workflow pod resource sizing
  - `CAPACITY_AWARE_RUNNER_CPU/MEMORY` — runner pod resource sizing (defaults: `750m`/`512Mi`)
  - `CAPACITY_AWARE_NODE_FLEET`, `CAPACITY_AWARE_RUNNER_CLASS` — node targeting
  - `CAPACITY_AWARE_HUD_API_TOKEN` — PyTorch HUD API auth token

## Testing
- Comprehensive unit test suite across all four source files (~1400 lines of tests):
  - `config_test.go` — defaults, env parsing, whitespace trimming, boundary clamping (negative, hard cap, warn threshold), Validate()
  - `hud_client_test.go` — happy path, label filtering, multi-label aggregation, empty labels, server errors, timeouts, malformed JSON
  - `placeholder_test.go` — CreatePair, DeletePair, ListPairs, CleanupTimedOut, CleanupOrphans (scoped to scale set), CleanupAll, BothRunning, AnyPendingTooLong; includes custom fake clientset reactor for DeleteCollection
  - `pod_spec_test.go` — nodeSelector/toleration/affinity correctness for all config combos (no GPU/fleet/class, with GPU/fleet/class), resource requests=limits, ephemeral storage, Karpenter annotation, sleep infinity command, pod name truncation with hash suffix uniqueness, invalid quantity graceful degradation
  - `monitor_test.go` — reconcile with zero queued, queued jobs additive, MaxRunners cap, scale-down preferring Pending, double-delete regression, MaxRunners=0 unlimited semantics, HUD API failure fallback, idempotent reconcile, Run loop cancellation cleanup
- Run tests: `go test ./cmd/ghalistener/capacity/...`