### PR TITLE
Override scaleset client timeout to avoid long controller stalls

### DIFF
--- a/controllers/actions.github.com/multiclient/multi_client.go
+++ b/controllers/actions.github.com/multiclient/multi_client.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/actions/actions-runner-controller/apis/actions.github.com/v1alpha1/appconfig"
 	"github.com/actions/actions-runner-controller/build"
@@ -135,7 +136,10 @@ func (o *ClientForOptions) newClient() (*scaleset.Client, error) {
 		Subsystem:  "gha-scale-set-controller",
 	}
 
-	var options []scaleset.HTTPOption
+	options := []scaleset.HTTPOption{
+		scaleset.WithTimeout(30 * time.Second),
+		scaleset.WithRetryMax(2),
+	}
 	if o.RootCAs != nil {
 		options = append(options, scaleset.WithRootCAs(o.RootCAs))
 	}


### PR DESCRIPTION
We've been observing frequent connection issues to `broker.actions.githubusercontent.com` in the past weeks, and that has caused the scaleset controller to lock for 15-20 minute periods up to 10 times a day during work hours. 

By "locking" I mean that EphemeralRunner resources stop being processed. The `status` field on them starts mismatching the actual runner pod status and new EphemeralRunners created on the cluster received blank `status` fields. 

In `workqueue_unfinished_work_seconds` metrics, we've noticed that the `controller="ephemeralrunner"` metric would keep raising for that whole "lock" period, and log lines for the EphemeralRunner controller stop being printed. We're also noticing `Client.Timeout exceeded` and `context canceled` on `broker.actions.githubusercontent.com` during that period. 

```
  2026-04-16 19:49:29 [DEBUG] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview                                             
  2026-04-16 19:54:29 [ERR] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview request failed: Delete                        
  "https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview": context deadline exceeded (Client.Timeout exceeded while awaiting headers)  
  2026-04-16 19:54:29 [DEBUG] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview: retrying in 1s (4 left)                    
  2026-04-16 19:59:11 [ERR] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview request failed: Delete                        
  "https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview": context canceled                                                            
```

It seems to us that the [default scaleset client](https://github.com/actions/scaleset/blob/02ad99e7fe0fbd2928d69459d28a9848588557ee/common_client.go#L94-L107) 5 minute timeout and 4 retries configs are contributing to that ~20 minute stall. At least, it can cause any workqueue item to be stuck for way longer than they should be. 

Here we've reduced to something more reasonable (30 seconds and 2 retries) and the "stalls" we used to see previously now last under 2 minutes:
```
  2026-04-24 11:46:18 [ERR] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview request failed: Delete                        
  "https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview": context deadline exceeded (Client.Timeout exceeded while awaiting headers)  
  2026-04-24 11:46:49 [ERR] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview request failed: Delete
  "https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview": context deadline exceeded (Client.Timeout exceeded while awaiting headers)  
  2026-04-24 11:47:21 [ERR] DELETE https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview request failed: Delete
  "https://broker.actions.githubusercontent.com/rest/_apis/distributedtask/pools/0/agents/REDACTED?api-version=6.0-preview": context deadline exceeded (Client.Timeout exceeded while awaiting headers)  
```

I'm happy to change this to use config flags if you judge that's a better option, or please let me know if you think there's a better solution to this.

Note: I also tried to increase "runner-max-concurrent-reconciles", but all connections to broker started failing simultaneously, leaving us with all concurrent calls being stuck in the retry loop.