### PR TITLE
Fix empty GVK in OwnerReferences for modern controllers

### DIFF
--- a/controllers/actions.github.com/resourcebuilder.go
+++ b/controllers/actions.github.com/resourcebuilder.go
@@ -319,8 +319,8 @@ func (b *ResourceBuilder) newScaleSetListenerPod(autoscalingListener *v1alpha1.A
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         autoscalingListener.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-					Kind:               autoscalingListener.GetObjectKind().GroupVersionKind().Kind,
+					APIVersion:         v1alpha1.GroupVersion.String(),
+					Kind:               "AutoscalingListener",
 					UID:                autoscalingListener.GetUID(),
 					Name:               autoscalingListener.GetName(),
 					Controller:         new(true),
@@ -591,8 +591,8 @@ func (b *ResourceBuilder) newEphemeralRunnerSet(autoscalingRunnerSet *v1alpha1.A
 			Annotations:  annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         autoscalingRunnerSet.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-					Kind:               autoscalingRunnerSet.GetObjectKind().GroupVersionKind().Kind,
+					APIVersion:         v1alpha1.GroupVersion.String(),
+					Kind:               "AutoscalingRunnerSet",
 					UID:                autoscalingRunnerSet.GetUID(),
 					Name:               autoscalingRunnerSet.GetName(),
 					Controller:         new(true),
@@ -645,8 +645,8 @@ func (b *ResourceBuilder) newEphemeralRunner(ephemeralRunnerSet *v1alpha1.Epheme
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         ephemeralRunnerSet.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-					Kind:               ephemeralRunnerSet.GetObjectKind().GroupVersionKind().Kind,
+					APIVersion:         v1alpha1.GroupVersion.String(),
+					Kind:               "EphemeralRunnerSet",
 					UID:                ephemeralRunnerSet.GetUID(),
 					Name:               ephemeralRunnerSet.GetName(),
 					Controller:         new(true),
@@ -683,8 +683,8 @@ func (b *ResourceBuilder) newEphemeralRunnerPod(runner *v1alpha1.EphemeralRunner
 		Annotations: annotations,
 		OwnerReferences: []metav1.OwnerReference{
 			{
-				APIVersion:         runner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-				Kind:               runner.GetObjectKind().GroupVersionKind().Kind,
+				APIVersion:         v1alpha1.GroupVersion.String(),
+				Kind:               "EphemeralRunner",
 				UID:                runner.GetUID(),
 				Name:               runner.GetName(),
 				Controller:         new(true),

--- a/controllers/actions.github.com/resourcebuilder_test.go
+++ b/controllers/actions.github.com/resourcebuilder_test.go
@@ -291,9 +291,30 @@ func TestOwnershipRelationships(t *testing.T) {
 	ephemeralRunnerSet, err := b.newEphemeralRunnerSet(&autoscalingRunnerSet)
 	require.NoError(t, err)
 
+	// Create and test Listener Pod ownership
+	listener, err := b.newAutoScalingListener(&autoscalingRunnerSet, ephemeralRunnerSet, autoscalingRunnerSet.Namespace, "test:latest", nil)
+	require.NoError(t, err)
+	listener.UID = "test-listener-uid"
+	listenerServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-sa"},
+	}
+	listenerPod, err := b.newScaleSetListenerPod(listener, &corev1.Secret{}, listenerServiceAccount, nil)
+	require.NoError(t, err)
+
+	require.Len(t, listenerPod.OwnerReferences, 1, "Listener Pod should have exactly one owner reference")
+	ownerRef := listenerPod.OwnerReferences[0]
+	assert.Equal(t, v1alpha1.GroupVersion.String(), ownerRef.APIVersion, "Owner reference APIVersion should match GroupVersion")
+	assert.Equal(t, "AutoscalingListener", ownerRef.Kind, "Owner reference Kind should be AutoscalingListener")
+	assert.Equal(t, listener.GetName(), ownerRef.Name, "Owner reference name should match AutoscalingListener name")
+	assert.Equal(t, listener.GetUID(), ownerRef.UID, "Owner reference UID should match AutoscalingListener UID")
+	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
+	assert.Equal(t, true, *ownerRef.BlockOwnerDeletion, "BlockOwnerDeletion flag should be true")
+
 	// Test EphemeralRunnerSet ownership
 	require.Len(t, ephemeralRunnerSet.OwnerReferences, 1, "EphemeralRunnerSet should have exactly one owner reference")
-	ownerRef := ephemeralRunnerSet.OwnerReferences[0]
+	ownerRef = ephemeralRunnerSet.OwnerReferences[0]
+	assert.Equal(t, v1alpha1.GroupVersion.String(), ownerRef.APIVersion, "Owner reference APIVersion should match GroupVersion")
+	assert.Equal(t, "AutoscalingRunnerSet", ownerRef.Kind, "Owner reference Kind should be AutoscalingRunnerSet")
 	assert.Equal(t, autoscalingRunnerSet.GetName(), ownerRef.Name, "Owner reference name should match AutoscalingRunnerSet name")
 	assert.Equal(t, autoscalingRunnerSet.GetUID(), ownerRef.UID, "Owner reference UID should match AutoscalingRunnerSet UID")
 	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
@@ -305,6 +326,8 @@ func TestOwnershipRelationships(t *testing.T) {
 	// Test EphemeralRunner ownership
 	require.Len(t, ephemeralRunner.OwnerReferences, 1, "EphemeralRunner should have exactly one owner reference")
 	ownerRef = ephemeralRunner.OwnerReferences[0]
+	assert.Equal(t, v1alpha1.GroupVersion.String(), ownerRef.APIVersion, "Owner reference APIVersion should match GroupVersion")
+	assert.Equal(t, "EphemeralRunnerSet", ownerRef.Kind, "Owner reference Kind should be EphemeralRunnerSet")
 	assert.Equal(t, ephemeralRunnerSet.GetName(), ownerRef.Name, "Owner reference name should match EphemeralRunnerSet name")
 	assert.Equal(t, ephemeralRunnerSet.GetUID(), ownerRef.UID, "Owner reference UID should match EphemeralRunnerSet UID")
 	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")
@@ -321,6 +344,8 @@ func TestOwnershipRelationships(t *testing.T) {
 	// Test EphemeralRunnerPod ownership
 	require.Len(t, pod.OwnerReferences, 1, "EphemeralRunnerPod should have exactly one owner reference")
 	ownerRef = pod.OwnerReferences[0]
+	assert.Equal(t, v1alpha1.GroupVersion.String(), ownerRef.APIVersion, "Owner reference APIVersion should match GroupVersion")
+	assert.Equal(t, "EphemeralRunner", ownerRef.Kind, "Owner reference Kind should be EphemeralRunner")
 	assert.Equal(t, ephemeralRunner.GetName(), ownerRef.Name, "Owner reference name should match EphemeralRunner name")
 	assert.Equal(t, ephemeralRunner.GetUID(), ownerRef.UID, "Owner reference UID should match EphemeralRunner UID")
 	assert.Equal(t, true, *ownerRef.Controller, "Controller flag should be true")


### PR DESCRIPTION
## What

- Replace `GetObjectKind().GroupVersionKind()` with `v1alpha1.GroupVersion.String()` and static Kind strings when constructing OwnerReferences

## Why

Objects fetched from the Kubernetes API server have their `TypeMeta` (`apiVersion`, `kind`) stripped by controller-runtime's typed client.
As a result, `GetObjectKind().GroupVersionKind()` returns an empty `GroupVersionKind{}`, producing:

- `APIVersion: "/"` (empty GroupVersion stringified)
- `Kind: ""`

This means the OwnerReferences on child resources (Pods, EphemeralRunnerSets, EphemeralRunners) are malformed. Kubernetes garbage collection cannot resolve the owner, so **child resources leak when the parent is deleted**

cf. https://github.com/kubernetes-sigs/controller-runtime/issues/1517#issuecomment-839979174