### PR TITLE
fix(GH-2284): Put docker:dind in proper cgroup parent

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -115,9 +115,14 @@ args:
   - dockerd
   - --host=unix:///var/run/docker.sock
   - --group=$(DOCKER_GROUP_GID)
+  - --cgroup-parent=/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod${POD_UID//-/_}.slice
 env:
   - name: DOCKER_GROUP_GID
     value: "123"
+  - name: POD_UID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
 securityContext:
   privileged: true
 {{- if (ge (.Capabilities.KubeVersion.Minor | int) 29) }}


### PR DESCRIPTION
Hello,

This PR is fix for ticket openeded since 2023: https://github.com/actions/actions-runner-controller/issues/2284 .

The idea is to use dockerd [cgroup-parent flag](https://docs.docker.com/reference/cli/dockerd/#default-cgroup-parent) to put dind containers in proper control groups.