### PR TITLE
Add `context: .` to the docker/build-push-action

### DIFF
--- a/.github/workflows/gha-publish-chart.yaml
+++ b/.github/workflows/gha-publish-chart.yaml
@@ -103,6 +103,7 @@ jobs:
       - name: Build & push controller image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
+          context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: VERSION=${{ inputs.release_tag_name }}


### PR DESCRIPTION
cf. https://github.com/mercari/actions-runner-controller/pull/24

## What

Add `context: .` to the `docker/build-push-action` step in `gha-publish-chart.yaml` and `gha-validate-chart.yaml`.

## Why

Without `context`, the action falls back to the [Git context](https://github.com/docker/build-push-action#git-context) and re-clones the repo inside BuildKit, ignoring the workspace from `actions/checkout` (including any pre-build file mutations and `.dockerignore` processing). Setting `context: .` makes the checked-out workspace the source of truth and avoids the redundant clone.