### PR TITLE
docs: clarify listener metric label sources

### DIFF
--- a/charts/gha-runner-scale-set-experimental/values.yaml
+++ b/charts/gha-runner-scale-set-experimental/values.yaml
@@ -316,6 +316,9 @@ controllerServiceAccount:
 ## In order to avoid helm merging these fields, we left the metrics commented out.
 ## When configuring metrics, please uncomment the listenerMetrics object below.
 ## You can modify the configuration to remove the label or specify custom buckets for histogram.
+## Labels on counters and histograms are populated from job messages, while labels on gauges are
+## populated from the configured scale set scope. For example, the repository label will be empty
+## for organization-level and enterprise-level scale sets.
 ##
 ## If the buckets field is not specified, the default buckets will be applied. Default buckets are
 ## provided here for documentation purposes

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -150,6 +150,9 @@ githubConfigSecret:
 ## In order to avoid helm merging these fields, we left the metrics commented out.
 ## When configuring metrics, please uncomment the listenerMetrics object below.
 ## You can modify the configuration to remove the label or specify custom buckets for histogram.
+## Labels on counters and histograms are populated from job messages, while labels on gauges are
+## populated from the configured scale set scope. For example, the repository label will be empty
+## for organization-level and enterprise-level scale sets.
 ##
 ## If the buckets field is not specified, the default buckets will be applied. Default buckets are
 ## provided here for documentation purposes


### PR DESCRIPTION
## Summary

Clarifies the `listenerMetrics` examples in the `gha-runner-scale-set` chart values.

Based on the current implementation, gauge metrics such as `gha_running_jobs`, `gha_assigned_jobs`, and `gha_registered_runners` are recorded from scale set statistics using scale set labels. These labels come from the configured GitHub scope.

Counter and histogram metrics such as `gha_started_jobs_total`, `gha_completed_jobs_total`, and job duration metrics are recorded from job messages, so they can include job-level metadata such as repository and workflow information.

## Context

Refs #4304.

While investigating the issue, I found that:

* `NewExporter()` is called from `cmd/ghalistener/main.go`
* `ExporterConfig.Repository`, `ExporterConfig.Organization`, and `ExporterConfig.Enterprise` are derived from `actions.ParseGitHubConfigFromURL(config.ConfigureURL)`
* `config.ConfigureURL` comes from the listener config secret generated from `AutoscalingRunnerSet.Spec.GitHubConfigUrl`
* `ParseGitHubConfigFromURL()` populates scope values based on the configured URL:

  * `/org/repo` populates repository scope
  * `/org` populates organization scope
  * `/enterprises/foo` populates enterprise scope

Because of this, gauge metrics appear to reflect the configured scale set scope rather than per-job metadata. This change clarifies that expectation in the chart values examples instead of deriving gauge labels from job messages.

## Changes

* Updated `charts/gha-runner-scale-set/values.yaml`
* Updated `charts/gha-runner-scale-set-experimental/values.yaml`
* Added comments clarifying that gauge labels come from scale set scope, while counter and histogram labels can come from job messages

## Testing

* Ran `git diff --check`

No Go tests or Helm rendering tests were run because this change only updates commented examples in `values.yaml` and does not affect rendered manifests or Go behavior.
