### PR TITLE
chart: add topologySpreadConstraints defaults

### DIFF
--- a/charts/actions-runner-controller/values.yaml
+++ b/charts/actions-runner-controller/values.yaml
@@ -141,6 +141,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 # Only one of minAvailable or maxUnavailable can be set
 podDisruptionBudget:
   enabled: false
@@ -246,6 +248,7 @@ githubWebhookServer:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
   priorityClassName: ""
   service:
     type: ClusterIP
@@ -382,6 +385,7 @@ actionsMetricsServer:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadConstraints: []
   priorityClassName: ""
   service:
     type: ClusterIP


### PR DESCRIPTION
## Summary

Adds missing `topologySpreadConstraints` defaults to the legacy `actions-runner-controller` chart values.

The chart templates and README already support topology spread constraints for:

* the controller pod
* the GitHub webhook server pod
* the actions metrics server pod

However, the corresponding default entries were missing from `charts/actions-runner-controller/values.yaml`, unlike similar scheduling-related fields such as `nodeSelector`, `tolerations`, and `affinity`.

## Context

Refs #4097.

While investigating the issue, I found that the templates already render:

* `.Values.topologySpreadConstraints`
* `.Values.githubWebhookServer.topologySpreadConstraints`
* `.Values.actionsMetricsServer.topologySpreadConstraints`

The README also documents these values, so this change only adds the missing defaults to `values.yaml` for consistency and discoverability.

## Changes

* Added root `topologySpreadConstraints: []`
* Added `githubWebhookServer.topologySpreadConstraints: []`
* Added `actionsMetricsServer.topologySpreadConstraints: []`

## Testing

* Ran `git diff --check`
* Ran `helm template` for the controller topology spread constraints
* Ran `helm template` for `githubWebhookServer.topologySpreadConstraints`
* Ran `helm template` for `actionsMetricsServer.topologySpreadConstraints`
