### PR TITLE
(feat) Rootless dind mode

### DIFF
--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -110,7 +110,8 @@ volumeMounts:
 {{- end }}
 
 {{- define "gha-runner-scale-set.dind-container" -}}
-image: docker:dind
+{{- $rootless := and .Values.containerMode (.Values.containerMode.rootless) }}
+image: {{ if $rootless }}docker:dind-rootless{{ else }}docker:dind{{ end }}
 args:
   - dockerd
   - --host=unix:///var/run/docker.sock
@@ -119,7 +120,15 @@ env:
   - name: DOCKER_GROUP_GID
     value: "123"
 securityContext:
+{{- if $rootless }}
+  privileged: false
+  appArmorProfile:
+    type: Unconfined
+  seccompProfile:
+    type: Unconfined
+{{- else }}
   privileged: true
+{{- end }}
 {{- if (ge (.Capabilities.KubeVersion.Minor | int) 29) }}
 restartPolicy: Always
 startupProbe:

--- a/charts/gha-runner-scale-set/values.yaml
+++ b/charts/gha-runner-scale-set/values.yaml
@@ -118,6 +118,10 @@ githubConfigSecret:
 ## empty, and configuration should be applied to the template.
 # containerMode:
 #   type: "dind"  ## type can be set to "dind", "kubernetes", or "kubernetes-novolume"
+#   ## When containerMode.type=dind, set rootless to true to run the dind container
+#   ## using the "docker:dind-rootless" image without privileged mode. The dind
+#   ## container instead runs with an Unconfined AppArmor and seccomp profile.
+#   rootless: false
 #   ## the following is required when containerMode.type=kubernetes
 #   kubernetesModeWorkVolumeClaim:
 #     accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
Currently we can't overwrite the dind deployment to use rootless mode, this updates the dind deployment to use rootless mode instead of privileged mode when required