### PR TITLE
Fix inconsistent guards for scale set metrics registration and publishing

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,7 +280,11 @@ func main() {
 			os.Exit(1)
 		}
 
-		if metricsAddr != "" {
+		// controller-runtime disables its metrics server when BindAddress is
+		// "0"; treat both "0" and "" as metrics disabled so registration and
+		// publishing stay consistent.
+		metricsEnabled := metricsAddr != "" && metricsAddr != "0"
+		if metricsEnabled {
 			log.Info("Registering scale set metrics")
 			actionsgithubcommetrics.RegisterMetrics()
 		}
@@ -350,7 +354,7 @@ func main() {
 			Client:          mgr.GetClient(),
 			Log:             log.WithName("EphemeralRunnerSet").WithValues("version", build.Version),
 			Scheme:          mgr.GetScheme(),
-			PublishMetrics:  metricsAddr != "0",
+			PublishMetrics:  metricsEnabled,
 			ResourceBuilder: rb,
 		}).SetupWithManager(mgr, controllerOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunnerSet")


### PR DESCRIPTION
## What

Introduce a single `metricsEnabled` condition (`metricsAddr != "" && metricsAddr != "0"`) and use it for both:

- `actionsgithubcommetrics.RegisterMetrics()` (previously guarded by `metricsAddr != ""`)
- `EphemeralRunnerSetReconciler.PublishMetrics` (previously `metricsAddr != "0"`)

## Why

Registration was guarded by `metricsAddr != ""` while publishing was guarded by `metricsAddr != "0"`, so the two could disagree. 

controller-runtime treats "0" - not "" - as the token to disable its metrics server.
Options.BindAddress documents "Set this to 0 to disable the metrics server", and NewServer returns nil when `BindAddress == "0"`. FYI:

https://github.com/kubernetes-sigs/controller-runtime/blob/3be3f1bf2b2fcc6b5c9510d55c6a9972294653d0/pkg/metrics/server/server.go#L119-L122

The Helm chart accordingly passes `--metrics-addr=0` when metrics are disabled.

With `metricsAddr=""`, the old guards skipped registration but still published: the reconciler keeps calling `WithLabelValues().Set()` on an unregistered GaugeVec, accumulating per-label child metrics in memory until restart while nothing is ever scraped. 

Aligning both guards on one metricsEnabled condition treats "" and "0" consistently as "metrics disabled"