### PR TITLE
Remove AutoscalingRunnerSet printer columns referencing removed status fields

### DIFF
--- a/apis/actions.github.com/v1alpha1/autoscalingrunnerset_types.go
+++ b/apis/actions.github.com/v1alpha1/autoscalingrunnerset_types.go
@@ -36,12 +36,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".spec.minRunners",name=Minimum Runners,type=integer
 // +kubebuilder:printcolumn:JSONPath=".spec.maxRunners",name=Maximum Runners,type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.currentRunners",name=Current Runners,type=integer
 // +kubebuilder:printcolumn:JSONPath=".status.phase",name=Phase,type=string
-// +kubebuilder:printcolumn:JSONPath=".status.pendingEphemeralRunners",name=Pending Runners,type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.runningEphemeralRunners",name=Running Runners,type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.finishedEphemeralRunners",name=Finished Runners,type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.deletingEphemeralRunners",name=Deleting Runners,type=integer
 
 // AutoscalingRunnerSet is the Schema for the autoscalingrunnersets API
 type AutoscalingRunnerSet struct {

--- a/charts/gha-runner-scale-set-controller-experimental/crds/actions.github.com_autoscalingrunnersets.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/crds/actions.github.com_autoscalingrunnersets.yaml
@@ -21,24 +21,9 @@ spec:
         - jsonPath: .spec.maxRunners
           name: Maximum Runners
           type: integer
-        - jsonPath: .status.currentRunners
-          name: Current Runners
-          type: integer
         - jsonPath: .status.phase
           name: Phase
           type: string
-        - jsonPath: .status.pendingEphemeralRunners
-          name: Pending Runners
-          type: integer
-        - jsonPath: .status.runningEphemeralRunners
-          name: Running Runners
-          type: integer
-        - jsonPath: .status.finishedEphemeralRunners
-          name: Finished Runners
-          type: integer
-        - jsonPath: .status.deletingEphemeralRunners
-          name: Deleting Runners
-          type: integer
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/charts/gha-runner-scale-set-controller/crds/actions.github.com_autoscalingrunnersets.yaml
+++ b/charts/gha-runner-scale-set-controller/crds/actions.github.com_autoscalingrunnersets.yaml
@@ -21,24 +21,9 @@ spec:
         - jsonPath: .spec.maxRunners
           name: Maximum Runners
           type: integer
-        - jsonPath: .status.currentRunners
-          name: Current Runners
-          type: integer
         - jsonPath: .status.phase
           name: Phase
           type: string
-        - jsonPath: .status.pendingEphemeralRunners
-          name: Pending Runners
-          type: integer
-        - jsonPath: .status.runningEphemeralRunners
-          name: Running Runners
-          type: integer
-        - jsonPath: .status.finishedEphemeralRunners
-          name: Finished Runners
-          type: integer
-        - jsonPath: .status.deletingEphemeralRunners
-          name: Deleting Runners
-          type: integer
       name: v1alpha1
       schema:
         openAPIV3Schema:

--- a/config/crd/bases/actions.github.com_autoscalingrunnersets.yaml
+++ b/config/crd/bases/actions.github.com_autoscalingrunnersets.yaml
@@ -21,24 +21,9 @@ spec:
         - jsonPath: .spec.maxRunners
           name: Maximum Runners
           type: integer
-        - jsonPath: .status.currentRunners
-          name: Current Runners
-          type: integer
         - jsonPath: .status.phase
           name: Phase
           type: string
-        - jsonPath: .status.pendingEphemeralRunners
-          name: Pending Runners
-          type: integer
-        - jsonPath: .status.runningEphemeralRunners
-          name: Running Runners
-          type: integer
-        - jsonPath: .status.finishedEphemeralRunners
-          name: Finished Runners
-          type: integer
-        - jsonPath: .status.deletingEphemeralRunners
-          name: Deleting Runners
-          type: integer
       name: v1alpha1
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
## What

Remove the 5 `AutoscalingRunnerSet` printer columns that reference status fields missing from the schema, and regenerate the CRDs with `make manifests`. 
The hand-written change is 5 deleted marker lines; the rest is generated.

Before:

```console
$ k get autoscalingrunnersets
NAME              MINIMUM RUNNERS   MAXIMUM RUNNERS   CURRENT RUNNERS   PHASE   PENDING RUNNERS   RUNNING RUNNERS   FINISHED RUNNERS   DELETING RUNNERS
dummy-scale-set   1                 5
```

After:

```console
$ k get autoscalingrunnersets
NAME              MINIMUM RUNNERS   MAXIMUM RUNNERS   PHASE
dummy-scale-set   1                 5
```

## Why

#4557 removed the runner-count fields from `AutoscalingRunnerSetStatus` (they are now exposed as controller metrics) and dropped the matching printer columns on `EphemeralRunnerSet`, but the `AutoscalingRunnerSet` markers were left behind so the 5 columns above always render empty.