### PR TITLE
Fix swallowed error when resolving organization runner group scale targets

### DIFF
--- a/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go
+++ b/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go
@@ -470,7 +470,7 @@ func (autoscaler *HorizontalRunnerAutoscalerGitHubWebhook) getScaleUpTargetWithF
 	})
 
 	if traverseErr != nil {
-		return nil, err
+		return nil, traverseErr
 	}
 
 	if t == nil {

--- a/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook_test.go
+++ b/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook_test.go
@@ -2,6 +2,7 @@ package actionssummerwindnet
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -360,6 +361,69 @@ func TestWebhookWorkflowJobWithSelfHostedLabel(t *testing.T) {
 			initObjs,
 		)
 	})
+}
+
+// TestGetScaleUpTargetWithFunctionPropagatesTraverseError ensures that an error hit while
+// resolving a candidate organization/enterprise runner group is returned to the caller
+// instead of being silently swallowed. Previously the error from visibleGroups.Traverse
+// was discarded because it was checked via a shadowed `err` variable, causing the webhook
+// to respond as if no matching HorizontalRunnerAutoscaler existed instead of surfacing the
+// real error.
+func TestGetScaleUpTargetWithFunctionPropagatesTraverseError(t *testing.T) {
+	hra := &actionsv1alpha1.HorizontalRunnerAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-name",
+		},
+		Spec: actionsv1alpha1.HorizontalRunnerAutoscalerSpec{
+			ScaleTargetRef: actionsv1alpha1.ScaleTargetRef{
+				Name: "test-name",
+			},
+		},
+	}
+
+	rd := &actionsv1alpha1.RunnerDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-name",
+		},
+		Spec: actionsv1alpha1.RunnerDeploymentSpec{
+			Template: actionsv1alpha1.RunnerTemplate{
+				Spec: actionsv1alpha1.RunnerSpec{
+					RunnerConfig: actionsv1alpha1.RunnerConfig{
+						Organization: "MYORG",
+					},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(sc).
+		WithRuntimeObjects(hra, rd).
+		Build()
+
+	autoscaler := &HorizontalRunnerAutoscalerGitHubWebhook{
+		Client: client,
+		Log:    logr.Discard(),
+	}
+
+	wantErr := fmt.Errorf("boom: transient error while resolving runner group")
+
+	// Simulate a repo-scoped lookup miss followed by a failure while resolving the
+	// organization-scoped runner group candidate found via getManagedRunnerGroupsFromHRAs.
+	scaleTarget := func(value string) (*ScaleTarget, error) {
+		if value == "MYORG/myrepo" {
+			return nil, nil
+		}
+		return nil, wantErr
+	}
+
+	_, err := autoscaler.getScaleUpTargetWithFunction(context.Background(), logr.Discard(), "myrepo", "MYORG", "Organization", "", scaleTarget)
+	if err == nil {
+		t.Fatal("expected the error raised while resolving a candidate runner group to propagate, got nil")
+	}
+	if err.Error() != wantErr.Error() {
+		t.Fatalf("expected error %q to propagate unchanged, got %q", wantErr, err)
+	}
 }
 
 func TestGetRequest(t *testing.T) {

--- a/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook_test.go
+++ b/controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook_test.go
@@ -422,7 +422,7 @@ func TestGetScaleUpTargetWithFunctionPropagatesTraverseError(t *testing.T) {
 		t.Fatal("expected the error raised while resolving a candidate runner group to propagate, got nil")
 	}
 	if err.Error() != wantErr.Error() {
-		t.Fatalf("expected error %q to propagate unchanged, got %q", wantErr, err)
+		t.Fatalf("expected error %v to propagate unchanged, got %v", wantErr, err)
 	}
 }
 


### PR DESCRIPTION
Motivation:
In getScaleUpTargetWithFunction (controllers/actions.summerwind.net/horizontal_runner_autoscaler_webhook.go),
the outer `err` variable from an earlier call was shadowed by a new `err`
declared inside the closure passed to visibleGroups.Traverse. When Traverse
returned a non-nil traverseErr, the function checked `traverseErr != nil` but
then returned the stale outer `err` (nil) instead of traverseErr. As a result,
any real error encountered while resolving an organization/enterprise runner
group candidate (e.g. a transient k8s API error) was logged once and then
discarded: the webhook handler treated it as "no matching
HorizontalRunnerAutoscaler for this event", responded 200 OK, and GitHub
recorded a successful delivery with no visible failure anywhere.

This is a plausible contributing cause of reports like the one below, where
webhook-driven autoscaling silently does nothing for one organization while
working for another sharing the same webhook endpoint - a failure in that
org's runner-group resolution would be swallowed exactly this way, leaving no
error trail to diagnose. This is not a complete diagnosis of that report:
other explanations (GitHub App/PAT lacking access to the second org,
mismatched per-org webhook secrets, or --watch-namespace scoping) remain
possible and were not ruled out here.

Approach:
Return the actual `traverseErr` instead of the shadowed outer `err`.

Validation:
Added TestGetScaleUpTargetWithFunctionPropagatesTraverseError, which injects
a scaleTarget function that fails for the organization-scoped key and asserts
the error propagates out of getScaleUpTargetWithFunction. Confirmed the test
fails on the pre-fix code (returns nil error instead of the injected one) and
passes after the fix:

  go test ./controllers/actions.summerwind.net/... -run TestGetScaleUpTargetWithFunctionPropagatesTraverseError -v

Also ran the full non-envtest test suite for the affected package (all
webhook-related tests pass) and `go build ./...` and `go vet
./controllers/actions.summerwind.net/...`, both clean. The Ginkgo/envtest
suite (TestAPIs) in this package requires local etcd/kube-apiserver binaries
that are not available in this environment; it fails identically on
unmodified master, so this is a pre-existing environment limitation unrelated
to this change, not a regression.

Report: https://github.com/actions/actions-runner-controller/issues/4246
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #4246