### PR TITLE
Skip service cleanup for EphemeralRunners that never registered

### DIFF
--- a/controllers/actions.github.com/ephemeralrunner_controller.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller.go
@@ -104,15 +104,19 @@ func (r *EphemeralRunnerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		if controllerutil.ContainsFinalizer(&ephemeralRunner, ephemeralRunnerActionsFinalizerName) {
-			log.Info("Trying to clean up runner from the service")
-			ok, err := r.cleanupRunnerFromService(ctx, &ephemeralRunner, log)
-			if err != nil {
-				log.Error(err, "Failed to clean up runner from service")
-				return ctrl.Result{}, err
-			}
-			if !ok {
-				log.Info("Runner is not finished yet, retrying in 30s")
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			if ephemeralRunner.Status.RunnerID == 0 {
+				log.Info("Runner was never registered with the service, skipping cleanup")
+			} else {
+				log.Info("Trying to clean up runner from the service")
+				ok, err := r.cleanupRunnerFromService(ctx, &ephemeralRunner, log)
+				if err != nil {
+					log.Error(err, "Failed to clean up runner from service")
+					return ctrl.Result{}, err
+				}
+				if !ok {
+					log.Info("Runner is not finished yet, retrying in 30s")
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				}
 			}
 
 			log.Info("Runner is cleaned up from the service, removing finalizer")

--- a/controllers/actions.github.com/ephemeralrunner_controller_test.go
+++ b/controllers/actions.github.com/ephemeralrunner_controller_test.go
@@ -779,6 +779,44 @@ var _ = Describe("EphemeralRunner", func() {
 			).Should(BeEquivalentTo(true))
 		})
 
+		It("It should delete an ephemeral runner whose config secret never existed", func() {
+			orphanRunner := newExampleRunner("test-runner-missing-secret", autoscalingNS.Name, "non-existent-secret")
+			err := k8sClient.Create(ctx, orphanRunner)
+			Expect(err).To(BeNil(), "failed to create ephemeral runner")
+
+			// Wait for finalizers to be added. From this point on, without the fix,
+			// deletion would try to clean up a runner that was never registered
+			// with the service and fail indefinitely because its GitHubConfigSecret
+			// does not exist.
+			Eventually(
+				func() ([]string, error) {
+					created := new(v1alpha1.EphemeralRunner)
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: orphanRunner.Name, Namespace: orphanRunner.Namespace}, created); err != nil {
+						return nil, err
+					}
+					return created.Finalizers, nil
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(ContainElements(ephemeralRunnerFinalizerName, ephemeralRunnerActionsFinalizerName))
+
+			err = k8sClient.Delete(ctx, orphanRunner)
+			Expect(err).To(BeNil(), "failed to delete ephemeral runner")
+
+			Eventually(
+				func() (bool, error) {
+					updated := new(v1alpha1.EphemeralRunner)
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: orphanRunner.Name, Namespace: orphanRunner.Namespace}, updated)
+					if err == nil {
+						return false, nil
+					}
+					return kerrors.IsNotFound(err), nil
+				},
+				ephemeralRunnerTimeout,
+				ephemeralRunnerInterval,
+			).Should(BeEquivalentTo(true))
+		})
+
 		It("It should eventually have runner id set", func() {
 			Eventually(
 				func() (int, error) {


### PR DESCRIPTION
Motivation:
When an AutoscalingRunnerSet is configured with a githubConfigSecret
that does not exist, its EphemeralRunners get both finalizers added
immediately on creation, before the secret is ever validated. If the
resource is then deleted, the finalizer-cleanup path always tries to
remove the runner from the GitHub Actions service, which requires
reading that (missing) secret to build an API client. That lookup
fails every time, so the finalizer is never removed and deletion
retries forever. The object is stuck in this infinite requeue loop
until the secret name is fixed; it is not a crash or data loss, and
other objects continue to reconcile normally.

Approach:
Status.RunnerID is only ever set after a JIT config has been
successfully obtained from a real secret, so RunnerID == 0 reliably
means the runner was never registered with the service. In the
deletion branch of EphemeralRunnerReconciler.Reconcile, skip the
call to cleanupRunnerFromService when RunnerID == 0 (there is
nothing registered to remove) and proceed directly to finalizer
removal. This mirrors the same RunnerID == 0 check already used in
EphemeralRunnerSetReconciler for the same purpose.

Validation:
Added a Ginkgo test, "It should delete an ephemeral runner whose
config secret never existed", that creates an EphemeralRunner
pointing at a nonexistent secret, waits for its finalizers to be
added, deletes it, and asserts it is fully removed within the
existing 20s timeout. Confirmed the test fails (times out waiting
for deletion) against the pre-fix code and passes after the fix,
reproducing the reported hang as a targeted regression test.

Ran, from the repo root with KUBEBUILDER_ASSETS pointed at the
existing envtest 1.36.2 binaries:
  go build ./controllers/...
  go vet ./controllers/actions.github.com/...
  golangci-lint run ./controllers/actions.github.com/...   (0 issues)
  go test ./controllers/actions.github.com/...              (ok, 79 specs)

Not run: a full-repo `go build ./...` / `go test ./...`, because the
local machine ran out of disk space while linking unrelated binaries
in this module. The change is confined to
controllers/actions.github.com, which was fully built and tested
above. Also not run: `make generate` / mockery codegen checks; this
change touches no API types and no interfaces, so both should be
no-ops.

Report: https://github.com/actions/actions-runner-controller/issues/4093
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #4093