### PR TITLE
Add default and per-controller max-concurrent-reconciles flags

### DIFF
--- a/charts/gha-runner-scale-set-controller-experimental/templates/_controller_template.tpl
+++ b/charts/gha-runner-scale-set-controller-experimental/templates/_controller_template.tpl
@@ -47,14 +47,20 @@ args:
 {{- with .Values.controller.manager.config.watchSingleNamespace }}
   - "--watch-single-namespace={{ . }}"
 {{- end }}
+{{- with .Values.controller.manager.config.defaultMaxConcurrentReconciles }}
+  - "--default-max-concurrent-reconciles={{ . }}"
+{{- end }}
+{{- with .Values.controller.manager.config.autoscalingRunnerSetMaxConcurrentReconciles }}
+  - "--autoscaling-runner-set-max-concurrent-reconciles={{ . }}"
+{{- end }}
+{{- with .Values.controller.manager.config.autoscalingListenerMaxConcurrentReconciles }}
+  - "--autoscaling-listener-max-concurrent-reconciles={{ . }}"
+{{- end }}
+{{- with .Values.controller.manager.config.ephemeralRunnerSetMaxConcurrentReconciles }}
+  - "--ephemeral-runner-set-max-concurrent-reconciles={{ . }}"
+{{- end }}
 {{- with .Values.controller.manager.config.runnerMaxConcurrentReconciles }}
-  - "--runner-max-concurrent-reconciles={{ . }}"
-{{- end }}
-{{- with .Values.controller.manager.config.listenerMaxConcurrentReconciles }}
-  - "--listener-max-concurrent-reconciles={{ . }}"
-{{- end }}
-{{- with .Values.controller.manager.config.scaleSetMaxConcurrentReconciles }}
-  - "--scale-set-max-concurrent-reconciles={{ . }}"
+  - "--ephemeral-runner-max-concurrent-reconciles={{ . }}"
 {{- end }}
 {{- if .Values.controller.metrics }}
 {{- with .Values.controller.metrics }}

--- a/charts/gha-runner-scale-set-controller-experimental/templates/_controller_template.tpl
+++ b/charts/gha-runner-scale-set-controller-experimental/templates/_controller_template.tpl
@@ -59,7 +59,7 @@ args:
 {{- with .Values.controller.manager.config.ephemeralRunnerSetMaxConcurrentReconciles }}
   - "--ephemeral-runner-set-max-concurrent-reconciles={{ . }}"
 {{- end }}
-{{- with .Values.controller.manager.config.runnerMaxConcurrentReconciles }}
+{{- with .Values.controller.manager.config.ephemeralRunnerMaxConcurrentReconciles }}
   - "--ephemeral-runner-max-concurrent-reconciles={{ . }}"
 {{- end }}
 {{- if .Values.controller.metrics }}

--- a/charts/gha-runner-scale-set-controller-experimental/templates/_controller_template.tpl
+++ b/charts/gha-runner-scale-set-controller-experimental/templates/_controller_template.tpl
@@ -50,6 +50,12 @@ args:
 {{- with .Values.controller.manager.config.runnerMaxConcurrentReconciles }}
   - "--runner-max-concurrent-reconciles={{ . }}"
 {{- end }}
+{{- with .Values.controller.manager.config.listenerMaxConcurrentReconciles }}
+  - "--listener-max-concurrent-reconciles={{ . }}"
+{{- end }}
+{{- with .Values.controller.manager.config.scaleSetMaxConcurrentReconciles }}
+  - "--scale-set-max-concurrent-reconciles={{ . }}"
+{{- end }}
 {{- if .Values.controller.metrics }}
 {{- with .Values.controller.metrics }}
   - "--listener-metrics-addr={{ .listenerAddr }}"

--- a/charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml
@@ -73,3 +73,40 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--listener-metrics-endpoint=/metrics"
+
+  - it: should include runner-max-concurrent-reconciles flag by default and omit listener and scale set flags
+    release:
+      name: "test-arc"
+      namespace: "test-ns"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--runner-max-concurrent-reconciles=2"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--listener-max-concurrent-reconciles=1"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--scale-set-max-concurrent-reconciles=1"
+
+  - it: should include listener and scale set max-concurrent-reconciles flags when configured
+    set:
+      controller:
+        manager:
+          config:
+            runnerMaxConcurrentReconciles: 20
+            listenerMaxConcurrentReconciles: 5
+            scaleSetMaxConcurrentReconciles: 3
+    release:
+      name: "test-arc"
+      namespace: "test-ns"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--runner-max-concurrent-reconciles=20"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--listener-max-concurrent-reconciles=5"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--scale-set-max-concurrent-reconciles=3"

--- a/charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml
@@ -74,39 +74,53 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--listener-metrics-endpoint=/metrics"
 
-  - it: should include runner-max-concurrent-reconciles flag by default and omit listener and scale set flags
+  - it: should include ephemeral-runner-max-concurrent-reconciles flag by default and omit the other concurrency flags
     release:
       name: "test-arc"
       namespace: "test-ns"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--runner-max-concurrent-reconciles=2"
+          content: "--ephemeral-runner-max-concurrent-reconciles=2"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--listener-max-concurrent-reconciles=1"
+          content: "--default-max-concurrent-reconciles=1"
       - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--scale-set-max-concurrent-reconciles=1"
+          content: "--autoscaling-runner-set-max-concurrent-reconciles=1"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--autoscaling-listener-max-concurrent-reconciles=1"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--ephemeral-runner-set-max-concurrent-reconciles=1"
 
-  - it: should include listener and scale set max-concurrent-reconciles flags when configured
+  - it: should include every max-concurrent-reconciles flag when configured
     set:
       controller:
         manager:
           config:
+            defaultMaxConcurrentReconciles: 4
+            autoscalingRunnerSetMaxConcurrentReconciles: 3
+            autoscalingListenerMaxConcurrentReconciles: 5
+            ephemeralRunnerSetMaxConcurrentReconciles: 6
             runnerMaxConcurrentReconciles: 20
-            listenerMaxConcurrentReconciles: 5
-            scaleSetMaxConcurrentReconciles: 3
     release:
       name: "test-arc"
       namespace: "test-ns"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--runner-max-concurrent-reconciles=20"
+          content: "--default-max-concurrent-reconciles=4"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--listener-max-concurrent-reconciles=5"
+          content: "--autoscaling-runner-set-max-concurrent-reconciles=3"
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--scale-set-max-concurrent-reconciles=3"
+          content: "--autoscaling-listener-max-concurrent-reconciles=5"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ephemeral-runner-set-max-concurrent-reconciles=6"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ephemeral-runner-max-concurrent-reconciles=20"

--- a/charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml
@@ -74,14 +74,14 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--listener-metrics-endpoint=/metrics"
 
-  - it: should include ephemeral-runner-max-concurrent-reconciles flag by default and omit the other concurrency flags
+  - it: should omit every max-concurrent-reconciles flag by default
     release:
       name: "test-arc"
       namespace: "test-ns"
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[0].args
-          content: "--ephemeral-runner-max-concurrent-reconciles=2"
+          content: "--ephemeral-runner-max-concurrent-reconciles=1"
       - notContains:
           path: spec.template.spec.containers[0].args
           content: "--default-max-concurrent-reconciles=1"
@@ -104,7 +104,7 @@ tests:
             autoscalingRunnerSetMaxConcurrentReconciles: 3
             autoscalingListenerMaxConcurrentReconciles: 5
             ephemeralRunnerSetMaxConcurrentReconciles: 6
-            runnerMaxConcurrentReconciles: 20
+            ephemeralRunnerMaxConcurrentReconciles: 20
     release:
       name: "test-arc"
       namespace: "test-ns"

--- a/charts/gha-runner-scale-set-controller-experimental/values.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/values.yaml
@@ -28,16 +28,17 @@ controller:
       # Defaults to watch all namespaces when unset.
       watchSingleNamespace: ""
 
+      # The maximum number of concurrent reconciles applied to every controller that does not
+      # set its own value below. Defaults to 1 when unset.
+      defaultMaxConcurrentReconciles: null
+
+      # Per-controller overrides. Each defaults to defaultMaxConcurrentReconciles when unset.
+      autoscalingRunnerSetMaxConcurrentReconciles: null
+      autoscalingListenerMaxConcurrentReconciles: null
+      ephemeralRunnerSetMaxConcurrentReconciles: null
+
       # The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
       runnerMaxConcurrentReconciles: 2
-
-      # The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller.
-      # Defaults to 1 when unset.
-      listenerMaxConcurrentReconciles: null
-
-      # The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet
-      # and EphemeralRunnerSet controllers. Defaults to 1 when unset.
-      scaleSetMaxConcurrentReconciles: null
 
       # List of label prefixes that should NOT be propagated to internal resources.
       excludeLabelPropagationPrefixes: []

--- a/charts/gha-runner-scale-set-controller-experimental/values.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/values.yaml
@@ -31,6 +31,14 @@ controller:
       # The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
       runnerMaxConcurrentReconciles: 2
 
+      # The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller.
+      # Defaults to 1 when unset.
+      listenerMaxConcurrentReconciles: null
+
+      # The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet
+      # and EphemeralRunnerSet controllers. Defaults to 1 when unset.
+      scaleSetMaxConcurrentReconciles: null
+
       # List of label prefixes that should NOT be propagated to internal resources.
       excludeLabelPropagationPrefixes: []
       # Example:

--- a/charts/gha-runner-scale-set-controller-experimental/values.yaml
+++ b/charts/gha-runner-scale-set-controller-experimental/values.yaml
@@ -36,9 +36,7 @@ controller:
       autoscalingRunnerSetMaxConcurrentReconciles: null
       autoscalingListenerMaxConcurrentReconciles: null
       ephemeralRunnerSetMaxConcurrentReconciles: null
-
-      # The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
-      runnerMaxConcurrentReconciles: 2
+      ephemeralRunnerMaxConcurrentReconciles: null
 
       # List of label prefixes that should NOT be propagated to internal resources.
       excludeLabelPropagationPrefixes: []

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -70,6 +70,12 @@ spec:
         {{- with .Values.flags.runnerMaxConcurrentReconciles }}
         - "--runner-max-concurrent-reconciles={{ . }}"
         {{- end }}
+        {{- with .Values.flags.listenerMaxConcurrentReconciles }}
+        - "--listener-max-concurrent-reconciles={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.scaleSetMaxConcurrentReconciles }}
+        - "--scale-set-max-concurrent-reconciles={{ . }}"
+        {{- end }}
         {{- if .Values.metrics }}
         {{- with .Values.metrics }}
         - "--listener-metrics-addr={{ .listenerAddr }}"

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -67,14 +67,20 @@ spec:
         {{- with .Values.flags.watchSingleNamespace }}
         - "--watch-single-namespace={{ . }}"
         {{- end }}
+        {{- with .Values.flags.defaultMaxConcurrentReconciles }}
+        - "--default-max-concurrent-reconciles={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.autoscalingRunnerSetMaxConcurrentReconciles }}
+        - "--autoscaling-runner-set-max-concurrent-reconciles={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.autoscalingListenerMaxConcurrentReconciles }}
+        - "--autoscaling-listener-max-concurrent-reconciles={{ . }}"
+        {{- end }}
+        {{- with .Values.flags.ephemeralRunnerSetMaxConcurrentReconciles }}
+        - "--ephemeral-runner-set-max-concurrent-reconciles={{ . }}"
+        {{- end }}
         {{- with .Values.flags.runnerMaxConcurrentReconciles }}
-        - "--runner-max-concurrent-reconciles={{ . }}"
-        {{- end }}
-        {{- with .Values.flags.listenerMaxConcurrentReconciles }}
-        - "--listener-max-concurrent-reconciles={{ . }}"
-        {{- end }}
-        {{- with .Values.flags.scaleSetMaxConcurrentReconciles }}
-        - "--scale-set-max-concurrent-reconciles={{ . }}"
+        - "--ephemeral-runner-max-concurrent-reconciles={{ . }}"
         {{- end }}
         {{- if .Values.metrics }}
         {{- with .Values.metrics }}

--- a/charts/gha-runner-scale-set-controller/templates/deployment.yaml
+++ b/charts/gha-runner-scale-set-controller/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
         {{- with .Values.flags.ephemeralRunnerSetMaxConcurrentReconciles }}
         - "--ephemeral-runner-set-max-concurrent-reconciles={{ . }}"
         {{- end }}
-        {{- with .Values.flags.runnerMaxConcurrentReconciles }}
+        {{- with .Values.flags.ephemeralRunnerMaxConcurrentReconciles }}
         - "--ephemeral-runner-max-concurrent-reconciles={{ . }}"
         {{- end }}
         {{- if .Values.metrics }}

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -366,7 +366,6 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 		"--metrics-addr=0",
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
-		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
 
@@ -518,7 +517,6 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -646,7 +644,6 @@ func TestTemplate_EnableLeaderElection(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -687,7 +684,6 @@ func TestTemplate_ControllerDeployment_ForwardImagePullSecrets(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -777,7 +773,6 @@ func TestTemplate_ControllerDeployment_WatchSingleNamespace(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -813,7 +808,7 @@ func TestTemplate_ControllerDeployment_MaxConcurrentReconciles(t *testing.T) {
 			"flags.autoscalingRunnerSetMaxConcurrentReconciles": "3",
 			"flags.autoscalingListenerMaxConcurrentReconciles":  "5",
 			"flags.ephemeralRunnerSetMaxConcurrentReconciles":   "6",
-			"flags.runnerMaxConcurrentReconciles":               "20",
+			"flags.ephemeralRunnerMaxConcurrentReconciles":      "20",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -366,7 +366,7 @@ func TestTemplate_ControllerDeployment_Defaults(t *testing.T) {
 		"--metrics-addr=0",
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
-		"--runner-max-concurrent-reconciles=2",
+		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
 
@@ -518,7 +518,7 @@ func TestTemplate_ControllerDeployment_Customize(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--runner-max-concurrent-reconciles=2",
+		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -646,7 +646,7 @@ func TestTemplate_EnableLeaderElection(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--runner-max-concurrent-reconciles=2",
+		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -687,7 +687,7 @@ func TestTemplate_ControllerDeployment_ForwardImagePullSecrets(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--runner-max-concurrent-reconciles=2",
+		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -777,7 +777,7 @@ func TestTemplate_ControllerDeployment_WatchSingleNamespace(t *testing.T) {
 		"--listener-metrics-addr=0",
 		"--listener-metrics-endpoint=",
 		"--metrics-addr=0",
-		"--runner-max-concurrent-reconciles=2",
+		"--ephemeral-runner-max-concurrent-reconciles=2",
 	}
 
 	assert.ElementsMatch(t, expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args)
@@ -809,9 +809,11 @@ func TestTemplate_ControllerDeployment_MaxConcurrentReconciles(t *testing.T) {
 	options := &helm.Options{
 		Logger: logger.Discard,
 		SetValues: map[string]string{
-			"flags.runnerMaxConcurrentReconciles":   "20",
-			"flags.listenerMaxConcurrentReconciles": "5",
-			"flags.scaleSetMaxConcurrentReconciles": "3",
+			"flags.defaultMaxConcurrentReconciles":              "4",
+			"flags.autoscalingRunnerSetMaxConcurrentReconciles": "3",
+			"flags.autoscalingListenerMaxConcurrentReconciles":  "5",
+			"flags.ephemeralRunnerSetMaxConcurrentReconciles":   "6",
+			"flags.runnerMaxConcurrentReconciles":               "20",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
@@ -823,9 +825,11 @@ func TestTemplate_ControllerDeployment_MaxConcurrentReconciles(t *testing.T) {
 
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 	args := deployment.Spec.Template.Spec.Containers[0].Args
-	assert.Contains(t, args, "--runner-max-concurrent-reconciles=20")
-	assert.Contains(t, args, "--listener-max-concurrent-reconciles=5")
-	assert.Contains(t, args, "--scale-set-max-concurrent-reconciles=3")
+	assert.Contains(t, args, "--default-max-concurrent-reconciles=4")
+	assert.Contains(t, args, "--autoscaling-runner-set-max-concurrent-reconciles=3")
+	assert.Contains(t, args, "--autoscaling-listener-max-concurrent-reconciles=5")
+	assert.Contains(t, args, "--ephemeral-runner-set-max-concurrent-reconciles=6")
+	assert.Contains(t, args, "--ephemeral-runner-max-concurrent-reconciles=20")
 }
 
 func TestTemplate_ControllerContainerEnvironmentVariables(t *testing.T) {

--- a/charts/gha-runner-scale-set-controller/tests/template_test.go
+++ b/charts/gha-runner-scale-set-controller/tests/template_test.go
@@ -796,6 +796,38 @@ func TestTemplate_ControllerDeployment_WatchSingleNamespace(t *testing.T) {
 	assert.Equal(t, "/tmp", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
 }
 
+func TestTemplate_ControllerDeployment_MaxConcurrentReconciles(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set-controller")
+	require.NoError(t, err)
+
+	releaseName := "test-arc"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"flags.runnerMaxConcurrentReconciles":   "20",
+			"flags.listenerMaxConcurrentReconciles": "5",
+			"flags.scaleSetMaxConcurrentReconciles": "3",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/deployment.yaml"})
+
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, output, &deployment)
+
+	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+	args := deployment.Spec.Template.Spec.Containers[0].Args
+	assert.Contains(t, args, "--runner-max-concurrent-reconciles=20")
+	assert.Contains(t, args, "--listener-max-concurrent-reconciles=5")
+	assert.Contains(t, args, "--scale-set-max-concurrent-reconciles=3")
+}
+
 func TestTemplate_ControllerContainerEnvironmentVariables(t *testing.T) {
 	t.Parallel()
 

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -114,20 +114,20 @@ flags:
   ## Defaults to watch all namespaces when unset.
   # watchSingleNamespace: ""
 
+  ## The maximum number of concurrent reconciles applied to every controller that does not set its own value below.
+  # Increase this value to improve the throughput of the controller when running many runner scale sets.
+  # It may also increase the load on the API server and the external service (e.g. GitHub API).
+  # defaultMaxConcurrentReconciles: 1
+
+  ## Per-controller overrides. Each defaults to defaultMaxConcurrentReconciles when unset.
+  # autoscalingRunnerSetMaxConcurrentReconciles: 1
+  # autoscalingListenerMaxConcurrentReconciles: 1
+  # ephemeralRunnerSetMaxConcurrentReconciles: 1
+
   ## The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
   # Increase this value to improve the throughput of the controller.
   # It may also increase the load on the API server and the external service (e.g. GitHub API).
   runnerMaxConcurrentReconciles: 2
-
-  ## The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller.
-  # Increase this value to improve the throughput of the controller when running many runner scale sets.
-  # It may also increase the load on the API server.
-  # listenerMaxConcurrentReconciles: 1
-
-  ## The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet and EphemeralRunnerSet controllers.
-  # Increase this value to improve the throughput of the controller when running many runner scale sets.
-  # It may also increase the load on the API server.
-  # scaleSetMaxConcurrentReconciles: 1
 
   ## Defines a list of prefixes that should not be propagated to internal resources.
   ## This is useful when you have labels that are used for internal purposes and should not be propagated to internal resources.

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -119,6 +119,16 @@ flags:
   # It may also increase the load on the API server and the external service (e.g. GitHub API).
   runnerMaxConcurrentReconciles: 2
 
+  ## The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller.
+  # Increase this value to improve the throughput of the controller when running many runner scale sets.
+  # It may also increase the load on the API server.
+  # listenerMaxConcurrentReconciles: 1
+
+  ## The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet and EphemeralRunnerSet controllers.
+  # Increase this value to improve the throughput of the controller when running many runner scale sets.
+  # It may also increase the load on the API server.
+  # scaleSetMaxConcurrentReconciles: 1
+
   ## Defines a list of prefixes that should not be propagated to internal resources.
   ## This is useful when you have labels that are used for internal purposes and should not be propagated to internal resources.
   ## See https://github.com/actions/actions-runner-controller/issues/3533 for more information.

--- a/charts/gha-runner-scale-set-controller/values.yaml
+++ b/charts/gha-runner-scale-set-controller/values.yaml
@@ -123,11 +123,7 @@ flags:
   # autoscalingRunnerSetMaxConcurrentReconciles: 1
   # autoscalingListenerMaxConcurrentReconciles: 1
   # ephemeralRunnerSetMaxConcurrentReconciles: 1
-
-  ## The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
-  # Increase this value to improve the throughput of the controller.
-  # It may also increase the load on the API server and the external service (e.g. GitHub API).
-  runnerMaxConcurrentReconciles: 2
+  # ephemeralRunnerMaxConcurrentReconciles: 1
 
   ## Defines a list of prefixes that should not be propagated to internal resources.
   ## This is useful when you have labels that are used for internal purposes and should not be propagated to internal resources.

--- a/controllers/actions.github.com/options.go
+++ b/controllers/actions.github.com/options.go
@@ -40,10 +40,14 @@ func OptionsWithDefault() Options {
 	}
 }
 
-// Resolve returns a copy of the options where every per-controller
+// Resolve returns a copy of the options where a DefaultMaxConcurrentReconciles
+// of zero or less is replaced by 1, and every per-controller
 // MaxConcurrentReconciles that is left at zero is replaced by
 // DefaultMaxConcurrentReconciles.
 func (o Options) Resolve() Options {
+	if o.DefaultMaxConcurrentReconciles <= 0 {
+		o.DefaultMaxConcurrentReconciles = 1
+	}
 	orDefault := func(n int) int {
 		if n > 0 {
 			return n

--- a/controllers/actions.github.com/options.go
+++ b/controllers/actions.github.com/options.go
@@ -10,17 +10,25 @@ import (
 // Options is the optional configuration for the controllers, which can be
 // set via command-line flags or environment variables.
 type Options struct {
-	// RunnerMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
-	// by the EphemeralRunnerController.
-	RunnerMaxConcurrentReconciles int
+	// DefaultMaxConcurrentReconciles is the maximum number of concurrent Reconciles
+	// applied to every controller that does not have its own value set below.
+	DefaultMaxConcurrentReconciles int
 
-	// ListenerMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
-	// by the AutoscalingListenerController.
-	ListenerMaxConcurrentReconciles int
+	// AutoscalingRunnerSetMaxConcurrentReconciles is the maximum number of concurrent Reconciles
+	// which can be run by the AutoscalingRunnerSetController. Zero means DefaultMaxConcurrentReconciles.
+	AutoscalingRunnerSetMaxConcurrentReconciles int
 
-	// ScaleSetMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
-	// by the AutoscalingRunnerSetController and the EphemeralRunnerSetController.
-	ScaleSetMaxConcurrentReconciles int
+	// AutoscalingListenerMaxConcurrentReconciles is the maximum number of concurrent Reconciles
+	// which can be run by the AutoscalingListenerController. Zero means DefaultMaxConcurrentReconciles.
+	AutoscalingListenerMaxConcurrentReconciles int
+
+	// EphemeralRunnerSetMaxConcurrentReconciles is the maximum number of concurrent Reconciles
+	// which can be run by the EphemeralRunnerSetController. Zero means DefaultMaxConcurrentReconciles.
+	EphemeralRunnerSetMaxConcurrentReconciles int
+
+	// EphemeralRunnerMaxConcurrentReconciles is the maximum number of concurrent Reconciles
+	// which can be run by the EphemeralRunnerController. Zero means DefaultMaxConcurrentReconciles.
+	EphemeralRunnerMaxConcurrentReconciles int
 }
 
 // OptionsWithDefault returns the default options.
@@ -28,10 +36,25 @@ type Options struct {
 // rather than having to correlate those in multiple places.
 func OptionsWithDefault() Options {
 	return Options{
-		RunnerMaxConcurrentReconciles:   2,
-		ListenerMaxConcurrentReconciles: 1,
-		ScaleSetMaxConcurrentReconciles: 1,
+		DefaultMaxConcurrentReconciles: 1,
 	}
+}
+
+// Resolve returns a copy of the options where every per-controller
+// MaxConcurrentReconciles that is left at zero is replaced by
+// DefaultMaxConcurrentReconciles.
+func (o Options) Resolve() Options {
+	orDefault := func(n int) int {
+		if n > 0 {
+			return n
+		}
+		return o.DefaultMaxConcurrentReconciles
+	}
+	o.AutoscalingRunnerSetMaxConcurrentReconciles = orDefault(o.AutoscalingRunnerSetMaxConcurrentReconciles)
+	o.AutoscalingListenerMaxConcurrentReconciles = orDefault(o.AutoscalingListenerMaxConcurrentReconciles)
+	o.EphemeralRunnerSetMaxConcurrentReconciles = orDefault(o.EphemeralRunnerSetMaxConcurrentReconciles)
+	o.EphemeralRunnerMaxConcurrentReconciles = orDefault(o.EphemeralRunnerMaxConcurrentReconciles)
+	return o
 }
 
 type Option func(*controller.Options)

--- a/controllers/actions.github.com/options.go
+++ b/controllers/actions.github.com/options.go
@@ -13,6 +13,14 @@ type Options struct {
 	// RunnerMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
 	// by the EphemeralRunnerController.
 	RunnerMaxConcurrentReconciles int
+
+	// ListenerMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
+	// by the AutoscalingListenerController.
+	ListenerMaxConcurrentReconciles int
+
+	// ScaleSetMaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run
+	// by the AutoscalingRunnerSetController and the EphemeralRunnerSetController.
+	ScaleSetMaxConcurrentReconciles int
 }
 
 // OptionsWithDefault returns the default options.
@@ -20,7 +28,9 @@ type Options struct {
 // rather than having to correlate those in multiple places.
 func OptionsWithDefault() Options {
 	return Options{
-		RunnerMaxConcurrentReconciles: 2,
+		RunnerMaxConcurrentReconciles:   2,
+		ListenerMaxConcurrentReconciles: 1,
+		ScaleSetMaxConcurrentReconciles: 1,
 	}
 }
 

--- a/controllers/actions.github.com/options_test.go
+++ b/controllers/actions.github.com/options_test.go
@@ -18,6 +18,18 @@ func TestOptionsResolve(t *testing.T) {
 		assert.Equal(t, 1, got.EphemeralRunnerMaxConcurrentReconciles)
 	})
 
+	t.Run("a default of zero or less is replaced by 1", func(t *testing.T) {
+		for _, n := range []int{0, -1} {
+			opts := Options{DefaultMaxConcurrentReconciles: n}
+			got := opts.Resolve()
+			assert.Equal(t, 1, got.DefaultMaxConcurrentReconciles)
+			assert.Equal(t, 1, got.AutoscalingRunnerSetMaxConcurrentReconciles)
+			assert.Equal(t, 1, got.AutoscalingListenerMaxConcurrentReconciles)
+			assert.Equal(t, 1, got.EphemeralRunnerSetMaxConcurrentReconciles)
+			assert.Equal(t, 1, got.EphemeralRunnerMaxConcurrentReconciles)
+		}
+	})
+
 	t.Run("a changed default applies to every unset controller", func(t *testing.T) {
 		opts := OptionsWithDefault()
 		opts.DefaultMaxConcurrentReconciles = 4

--- a/controllers/actions.github.com/options_test.go
+++ b/controllers/actions.github.com/options_test.go
@@ -1,0 +1,31 @@
+package actionsgithubcom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionsResolve(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unset per-controller values fall back to the default", func(t *testing.T) {
+		got := OptionsWithDefault().Resolve()
+		assert.Equal(t, 1, got.DefaultMaxConcurrentReconciles)
+		assert.Equal(t, 1, got.AutoscalingRunnerSetMaxConcurrentReconciles)
+		assert.Equal(t, 1, got.AutoscalingListenerMaxConcurrentReconciles)
+		assert.Equal(t, 1, got.EphemeralRunnerSetMaxConcurrentReconciles)
+		assert.Equal(t, 1, got.EphemeralRunnerMaxConcurrentReconciles)
+	})
+
+	t.Run("a changed default applies to every unset controller", func(t *testing.T) {
+		opts := OptionsWithDefault()
+		opts.DefaultMaxConcurrentReconciles = 4
+		opts.EphemeralRunnerMaxConcurrentReconciles = 20
+		got := opts.Resolve()
+		assert.Equal(t, 4, got.AutoscalingRunnerSetMaxConcurrentReconciles)
+		assert.Equal(t, 4, got.AutoscalingListenerMaxConcurrentReconciles)
+		assert.Equal(t, 4, got.EphemeralRunnerSetMaxConcurrentReconciles)
+		assert.Equal(t, 20, got.EphemeralRunnerMaxConcurrentReconciles)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -151,9 +151,11 @@ func main() {
 	flag.DurationVar(&defaultScaleDownDelay, "default-scale-down-delay", actionssummerwindnet.DefaultScaleDownDelay, "The approximate delay for a scale down followed by a scale up, used to prevent flapping (down->up->down->... loop)")
 	flag.IntVar(&port, "port", 9443, "The port to which the admission webhook endpoint should bind")
 	flag.DurationVar(&syncPeriod, "sync-period", 1*time.Minute, "Determines the minimum frequency at which K8s resources managed by this controller are reconciled.")
-	flag.IntVar(&opts.RunnerMaxConcurrentReconciles, "runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller. Increase this value to improve the throughput of the controller, but it may also increase the load on the API server and the external service (e.g. GitHub API).")
-	flag.IntVar(&opts.ListenerMaxConcurrentReconciles, "listener-max-concurrent-reconciles", opts.ListenerMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller. Increase this value to improve the throughput of the controller when running many runner scale sets, but it may also increase the load on the API server.")
-	flag.IntVar(&opts.ScaleSetMaxConcurrentReconciles, "scale-set-max-concurrent-reconciles", opts.ScaleSetMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet and EphemeralRunnerSet controllers. Increase this value to improve the throughput of the controller when running many runner scale sets, but it may also increase the load on the API server.")
+	flag.IntVar(&opts.DefaultMaxConcurrentReconciles, "default-max-concurrent-reconciles", opts.DefaultMaxConcurrentReconciles, "The maximum number of concurrent reconciles applied to every controller that does not set its own --<controller>-max-concurrent-reconciles flag. Increase this value to improve the throughput of the controller, but it may also increase the load on the API server and the external service (e.g. GitHub API).")
+	flag.IntVar(&opts.AutoscalingRunnerSetMaxConcurrentReconciles, "autoscaling-runner-set-max-concurrent-reconciles", 0, "The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet controller. Defaults to --default-max-concurrent-reconciles.")
+	flag.IntVar(&opts.AutoscalingListenerMaxConcurrentReconciles, "autoscaling-listener-max-concurrent-reconciles", 0, "The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller. Defaults to --default-max-concurrent-reconciles.")
+	flag.IntVar(&opts.EphemeralRunnerSetMaxConcurrentReconciles, "ephemeral-runner-set-max-concurrent-reconciles", 0, "The maximum number of concurrent reconciles which can be run by the EphemeralRunnerSet controller. Defaults to --default-max-concurrent-reconciles.")
+	flag.IntVar(&opts.EphemeralRunnerMaxConcurrentReconciles, "ephemeral-runner-max-concurrent-reconciles", 0, "The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller. Defaults to --default-max-concurrent-reconciles.")
 	flag.Var(&commonRunnerLabels, "common-runner-labels", "Runner labels in the K1=V1,K2=V2,... format that are inherited all the runners created by the controller. See https://github.com/actions/actions-runner-controller/issues/321 for more information")
 	flag.StringVar(&namespace, "watch-namespace", "", "The namespace to watch for custom resources. Set to empty for letting it watch for all namespaces.")
 	flag.StringVar(&watchSingleNamespace, "watch-single-namespace", "", "Restrict to watch for custom resources in a single namespace.")
@@ -167,6 +169,7 @@ func main() {
 	flag.StringVar(&workqueueRateLimiter, "workqueue-rate-limiter", "", `The workqueue rate limiter to use. Valid values are "bucket_rate_limiter" (default) and "typed_rate_limiter" (per-item only, no global token bucket).`)
 	flag.Parse()
 
+	opts = opts.Resolve()
 	runnerPodDefaults.RunnerImagePullSecrets = runnerImagePullSecrets
 
 	log, err := logging.NewLogger(logLevel, logFormat)
@@ -177,9 +180,11 @@ func main() {
 	c.Log = &log
 
 	log.Info("Using options",
-		"runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles,
-		"listener-max-concurrent-reconciles", opts.ListenerMaxConcurrentReconciles,
-		"scale-set-max-concurrent-reconciles", opts.ScaleSetMaxConcurrentReconciles,
+		"default-max-concurrent-reconciles", opts.DefaultMaxConcurrentReconciles,
+		"autoscaling-runner-set-max-concurrent-reconciles", opts.AutoscalingRunnerSetMaxConcurrentReconciles,
+		"autoscaling-listener-max-concurrent-reconciles", opts.AutoscalingListenerMaxConcurrentReconciles,
+		"ephemeral-runner-set-max-concurrent-reconciles", opts.EphemeralRunnerSetMaxConcurrentReconciles,
+		"ephemeral-runner-max-concurrent-reconciles", opts.EphemeralRunnerMaxConcurrentReconciles,
 	)
 
 	if !autoScalingRunnerSetOnly {
@@ -330,7 +335,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		scaleSetOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.ScaleSetMaxConcurrentReconciles))
+		autoscalingRunnerSetOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.AutoscalingRunnerSetMaxConcurrentReconciles))
 		if err = (&actionsgithubcom.AutoscalingRunnerSetReconciler{
 			Client:                             mgr.GetClient(),
 			Log:                                log.WithName("AutoscalingRunnerSet").WithValues("version", build.Version),
@@ -339,34 +344,35 @@ func main() {
 			DefaultRunnerScaleSetListenerImage: managerImage,
 			DefaultRunnerScaleSetListenerImagePullSecrets: autoScalerImagePullSecrets,
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr, scaleSetOpts...); err != nil {
+		}).SetupWithManager(mgr, autoscalingRunnerSetOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "AutoscalingRunnerSet")
 			os.Exit(1)
 		}
 
-		runnerOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.RunnerMaxConcurrentReconciles))
+		ephemeralRunnerOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.EphemeralRunnerMaxConcurrentReconciles))
 		if err = (&actionsgithubcom.EphemeralRunnerReconciler{
 			Client:          mgr.GetClient(),
 			Log:             log.WithName("EphemeralRunner").WithValues("version", build.Version),
 			Scheme:          mgr.GetScheme(),
 			PublishMetrics:  metricsAddr != "0",
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr, runnerOpts...); err != nil {
+		}).SetupWithManager(mgr, ephemeralRunnerOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunner")
 			os.Exit(1)
 		}
 
+		ephemeralRunnerSetOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.EphemeralRunnerSetMaxConcurrentReconciles))
 		if err = (&actionsgithubcom.EphemeralRunnerSetReconciler{
 			Client:          mgr.GetClient(),
 			Log:             log.WithName("EphemeralRunnerSet").WithValues("version", build.Version),
 			Scheme:          mgr.GetScheme(),
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr, scaleSetOpts...); err != nil {
+		}).SetupWithManager(mgr, ephemeralRunnerSetOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunnerSet")
 			os.Exit(1)
 		}
 
-		listenerOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.ListenerMaxConcurrentReconciles))
+		autoscalingListenerOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.AutoscalingListenerMaxConcurrentReconciles))
 		if err = (&actionsgithubcom.AutoscalingListenerReconciler{
 			Client:                  mgr.GetClient(),
 			Log:                     log.WithName("AutoscalingListener").WithValues("version", build.Version),
@@ -374,7 +380,7 @@ func main() {
 			ListenerMetricsAddr:     listenerMetricsAddr,
 			ListenerMetricsEndpoint: listenerMetricsEndpoint,
 			ResourceBuilder:         rb,
-		}).SetupWithManager(mgr, listenerOpts...); err != nil {
+		}).SetupWithManager(mgr, autoscalingListenerOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "AutoscalingListener")
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -152,6 +152,8 @@ func main() {
 	flag.IntVar(&port, "port", 9443, "The port to which the admission webhook endpoint should bind")
 	flag.DurationVar(&syncPeriod, "sync-period", 1*time.Minute, "Determines the minimum frequency at which K8s resources managed by this controller are reconciled.")
 	flag.IntVar(&opts.RunnerMaxConcurrentReconciles, "runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller. Increase this value to improve the throughput of the controller, but it may also increase the load on the API server and the external service (e.g. GitHub API).")
+	flag.IntVar(&opts.ListenerMaxConcurrentReconciles, "listener-max-concurrent-reconciles", opts.ListenerMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the AutoscalingListener controller. Increase this value to improve the throughput of the controller when running many runner scale sets, but it may also increase the load on the API server.")
+	flag.IntVar(&opts.ScaleSetMaxConcurrentReconciles, "scale-set-max-concurrent-reconciles", opts.ScaleSetMaxConcurrentReconciles, "The maximum number of concurrent reconciles which can be run by the AutoscalingRunnerSet and EphemeralRunnerSet controllers. Increase this value to improve the throughput of the controller when running many runner scale sets, but it may also increase the load on the API server.")
 	flag.Var(&commonRunnerLabels, "common-runner-labels", "Runner labels in the K1=V1,K2=V2,... format that are inherited all the runners created by the controller. See https://github.com/actions/actions-runner-controller/issues/321 for more information")
 	flag.StringVar(&namespace, "watch-namespace", "", "The namespace to watch for custom resources. Set to empty for letting it watch for all namespaces.")
 	flag.StringVar(&watchSingleNamespace, "watch-single-namespace", "", "Restrict to watch for custom resources in a single namespace.")
@@ -174,7 +176,11 @@ func main() {
 	}
 	c.Log = &log
 
-	log.Info("Using options", "runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles)
+	log.Info("Using options",
+		"runner-max-concurrent-reconciles", opts.RunnerMaxConcurrentReconciles,
+		"listener-max-concurrent-reconciles", opts.ListenerMaxConcurrentReconciles,
+		"scale-set-max-concurrent-reconciles", opts.ScaleSetMaxConcurrentReconciles,
+	)
 
 	if !autoScalingRunnerSetOnly {
 		ghClient, err = c.NewClient()
@@ -324,6 +330,7 @@ func main() {
 			os.Exit(1)
 		}
 
+		scaleSetOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.ScaleSetMaxConcurrentReconciles))
 		if err = (&actionsgithubcom.AutoscalingRunnerSetReconciler{
 			Client:                             mgr.GetClient(),
 			Log:                                log.WithName("AutoscalingRunnerSet").WithValues("version", build.Version),
@@ -332,7 +339,7 @@ func main() {
 			DefaultRunnerScaleSetListenerImage: managerImage,
 			DefaultRunnerScaleSetListenerImagePullSecrets: autoScalerImagePullSecrets,
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr, controllerOpts...); err != nil {
+		}).SetupWithManager(mgr, scaleSetOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "AutoscalingRunnerSet")
 			os.Exit(1)
 		}
@@ -354,11 +361,12 @@ func main() {
 			Log:             log.WithName("EphemeralRunnerSet").WithValues("version", build.Version),
 			Scheme:          mgr.GetScheme(),
 			ResourceBuilder: rb,
-		}).SetupWithManager(mgr, controllerOpts...); err != nil {
+		}).SetupWithManager(mgr, scaleSetOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "EphemeralRunnerSet")
 			os.Exit(1)
 		}
 
+		listenerOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.ListenerMaxConcurrentReconciles))
 		if err = (&actionsgithubcom.AutoscalingListenerReconciler{
 			Client:                  mgr.GetClient(),
 			Log:                     log.WithName("AutoscalingListener").WithValues("version", build.Version),
@@ -366,7 +374,7 @@ func main() {
 			ListenerMetricsAddr:     listenerMetricsAddr,
 			ListenerMetricsEndpoint: listenerMetricsEndpoint,
 			ResourceBuilder:         rb,
-		}).SetupWithManager(mgr, controllerOpts...); err != nil {
+		}).SetupWithManager(mgr, listenerOpts...); err != nil {
 			log.Error(err, "unable to create controller", "controller", "AutoscalingListener")
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Problem

The controller manager exposes one concurrency knob, `--runner-max-concurrent-reconciles` (chart value `flags.runnerMaxConcurrentReconciles`), but it only applies to the `EphemeralRunner` controller. The `AutoscalingListener`, `AutoscalingRunnerSet` and `EphemeralRunnerSet` controllers always run with controller-runtime's default of a single worker, and there is no flag or chart value that can change that.

In clusters with many runner scale sets (one `AutoscalingRunnerSet` per team/repo, or short-lived scale sets created from CI), the single `AutoscalingListener` worker serialises every listener reconcile (ServiceAccount, Role, RoleBinding, mirrored secret, listener Pod), so `workqueue_depth{name="autoscalinglistener"}` grows and listener Pods for new scale sets appear one at a time while the controller is otherwise idle. `--workqueue-rate-limiter=typed_rate_limiter` (#4451) does not help because the bottleneck is the worker count, not the queue rate.

`controller_runtime_max_concurrent_reconciles` on `master` (54147cf) with `runnerMaxConcurrentReconciles: 20`:

```
controller_runtime_max_concurrent_reconciles{controller="ephemeralrunner"} 20
controller_runtime_max_concurrent_reconciles{controller="ephemeralrunnerset"} 1
controller_runtime_max_concurrent_reconciles{controller="autoscalingrunnerset"} 1
controller_runtime_max_concurrent_reconciles{controller="autoscalinglistener"} 1
```

## Root cause

`main.go:340` builds `runnerOpts := append(controllerOpts, actionsgithubcom.WithMaxConcurrentReconciles(opts.RunnerMaxConcurrentReconciles))` and passes it only to `EphemeralRunnerReconciler.SetupWithManager` (`main.go:347`). The other three reconcilers (`main.go:335`, `main.go:357`, `main.go:369`) receive plain `controllerOpts`, which carries only the workqueue rate-limiter choice, so `controller.Options.MaxConcurrentReconciles` stays at 0 and controller-runtime defaults it to 1.

All three `SetupWithManager` methods already accept `opts ...Option` and go through `builderWithOptions` (`controllers/actions.github.com/options.go:66`), so nothing in the reconcilers prevents higher concurrency; the option was simply never wired for them (#3832 added it for `EphemeralRunner` only).

## Fix

Following review feedback, the concurrency knobs are now one default plus one flag per controller. Any per-controller flag left unset falls back to the default, and the default is 1. Following the second review round, the charts no longer carry the legacy `runnerMaxConcurrentReconciles` value: the `EphemeralRunner` override is `ephemeralRunnerMaxConcurrentReconciles` and, like the other overrides, is unset by default. A default chart install therefore renders no concurrency flags and every controller runs with 1 worker (`EphemeralRunner` previously rendered 2). The bare binary behaves the same. `Options.Resolve()` also replaces a default of 0 or less with 1 explicitly rather than relying on controller-runtime.

- `--default-max-concurrent-reconciles` (default 1), applied to every controller without its own value
- `--autoscaling-runner-set-max-concurrent-reconciles`
- `--autoscaling-listener-max-concurrent-reconciles`
- `--ephemeral-runner-set-max-concurrent-reconciles`
- `--ephemeral-runner-max-concurrent-reconciles` (renamed from `--runner-max-concurrent-reconciles`; the old flag is removed, 0.15.0 does not promise flag compatibility)

Changes:

- `controllers/actions.github.com/options.go`: one `Options` field per flag, `OptionsWithDefault()` sets only the default, and `Options.Resolve()` clamps a default of 0 or less to 1 and replaces every zero per-controller value with the default. Unit test in `options_test.go`.
- `main.go`: register the five flags, call `opts.Resolve()` after `flag.Parse()`, log all five resolved values, and pass a `WithMaxConcurrentReconciles(...)` option to each of the four `SetupWithManager` calls.
- `charts/gha-runner-scale-set-controller`: new `flags.defaultMaxConcurrentReconciles`, `flags.autoscalingRunnerSetMaxConcurrentReconciles`, `flags.autoscalingListenerMaxConcurrentReconciles`, `flags.ephemeralRunnerSetMaxConcurrentReconciles`, `flags.ephemeralRunnerMaxConcurrentReconciles` (documented, commented out). `flags.runnerMaxConcurrentReconciles` is removed.
- `charts/gha-runner-scale-set-controller-experimental`: the same five values under `controller.manager.config` (`null` by default), rendered by `templates/_controller_template.tpl`.

No CRD or RBAC changes.

## How tested

- `controllers/actions.github.com/options_test.go`: `TestOptionsResolve` covers the all-default case, a default of 0 or -1, and a changed default with one per-controller override.
- `charts/gha-runner-scale-set-controller/tests/template_test.go`: `TestTemplate_ControllerDeployment_MaxConcurrentReconciles` sets all five values and asserts the rendered args; the default-args assertions expect no concurrency flag.
- `charts/gha-runner-scale-set-controller-experimental/tests/controller_deployment_args_test.yaml` (helm-unittest): defaults render no concurrency flag; setting all five values renders all five flags.

```
go build ./... && go vet . ./controllers/actions.github.com/   # clean
go test ./controllers/actions.github.com/ -run TestOptionsResolve   # ok
go test ./charts/gha-runner-scale-set-controller/...              # ok
helm unittest ./charts/gha-runner-scale-set-controller-experimental/
Test Suites: 18 passed, 18 total
Tests:       42 passed, 42 total
helm lint charts/gha-runner-scale-set-controller/ charts/gha-runner-scale-set-controller-experimental/   # 0 failed

go run . --help | grep max-concurrent-reconciles
  -autoscaling-listener-max-concurrent-reconciles int
  -autoscaling-runner-set-max-concurrent-reconciles int
  -default-max-concurrent-reconciles int   (default 1)
  -ephemeral-runner-max-concurrent-reconciles int
  -ephemeral-runner-set-max-concurrent-reconciles int
```

Note for reviewers: `go test ./controllers/actions.github.com/...` currently fails on `master` (54147cf) in the pre-existing spec "AutoscalingRunnerSet with a stale runner scale set ... registers the runner scale set again" (same failure in the upstream `test` job for master, run 34118603425); this PR does not touch that path.

## Links

- Fixes https://github.com/actions/actions-runner-controller/issues/4624
- Related: #3021 (original request), #3832 (flag added for `EphemeralRunner` only), #4451 (workqueue rate limiter)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.




