### PR TITLE
Fix nil ResourceCache panic in stale scale set tests

### DIFF
--- a/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
+++ b/controllers/actions.github.com/autoscalingrunnerset_controller_test.go
@@ -2196,6 +2196,7 @@ var _ = Describe("Test AutoscalingRunnerSet with a stale runner scale set", Orde
 				ControllerNamespace:                autoscalingNS.Name,
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ResourceBuilder: ResourceBuilder{
+					ResourceCache: newTestResourceCache(),
 					SecretResolver: secretresolver.New(mgr.GetClient(), scalefake.NewMultiClient(
 						scalefake.WithClient(
 							scalefake.NewClient(
@@ -2268,6 +2269,7 @@ var _ = Describe("Test AutoscalingRunnerSet with a stale runner scale set", Orde
 				ControllerNamespace:                autoscalingNS.Name,
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ResourceBuilder: ResourceBuilder{
+					ResourceCache: newTestResourceCache(),
 					SecretResolver: secretresolver.New(mgr.GetClient(), scalefake.NewMultiClient(
 						scalefake.WithClient(
 							scalefake.NewClient(
@@ -2328,6 +2330,7 @@ var _ = Describe("Test AutoscalingRunnerSet with a stale runner scale set", Orde
 				ControllerNamespace:                autoscalingNS.Name,
 				DefaultRunnerScaleSetListenerImage: "ghcr.io/actions/arc",
 				ResourceBuilder: ResourceBuilder{
+					ResourceCache: newTestResourceCache(),
 					SecretResolver: secretresolver.New(mgr.GetClient(), scalefake.NewMultiClient(
 						scalefake.WithClient(
 							scalefake.NewClient(


### PR DESCRIPTION
## Problem

CI was failing on `TestAPIs` in `controllers/actions.github.com` with:

```
panic: runtime error: invalid memory address or nil pointer dereference
...(*AutoscalingRunnerSetReconciler).createEphemeralRunnerSet
...(*AutoscalingRunnerSetReconciler).Reconcile
```

in the "Test AutoscalingRunnerSet with a stale runner scale set" spec added by #4571.

The panic was deterministic given the test's state, so every retry (with the workqueue's exponential backoff) panicked again — this is also why later CI runs surfaced as a plain 20s timeout waiting for the annotation to be replaced, rather than a visible panic in the tail of the log.

## Root cause

`ResourceBuilder.ResourceCache` is a `*ResourceCache`. #4568 (merged after #4571) added a caching layer and made resource builders like `newEphemeralRunnerSet` dereference it directly:

```go
if cached, ok := b.ResourceCache.ephemeralRunnerSet.Get(autoscalingRunnerSet, cacheKeyObject); ok {
	return cached, nil
}
```

The three test `Context` blocks under "Test AutoscalingRunnerSet with a stale runner scale set" construct the reconciler manually and never set `ResourceCache`, unlike every other test in the file (which all set it via `newTestResourceCache()`). That leaves `b.ResourceCache` nil, so the first attempt to create an `EphemeralRunnerSet` dereferences a nil pointer to read the `ephemeralRunnerSet` field, producing exactly the observed panic.

## Fix

Initialize `ResourceCache: newTestResourceCache()` in all three contexts, matching the rest of the test file. This is a test-only change — no production code paths are affected (production wiring in `main.go` already initializes `ResourceCache` correctly).

## Verification

- `go build ./...` and `go vet ./controllers/actions.github.com/...` clean
- Full `controllers/actions.github.com` suite (all 78 specs, `-short`, real envtest) passes, including with envtest k8s 1.35.0 and 1.36.0
- Focused "stale runner scale set" specs run cleanly 20+ times in a row, including under `-race`
- Confirmed the panic reproduces without this fix (nil `*ResourceCache` field dereference) and disappears with it