### PR TITLE
Validate runner metadata labels and annotations at chart render time

### DIFF
--- a/charts/gha-runner-scale-set-experimental/templates/_autoscalingrunnerset.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_autoscalingrunnerset.tpl
@@ -32,11 +32,11 @@ Render a ResourceMeta block for AutoscalingRunnerSet spec fields.
 {{- define "autoscaling-runner-set.spec-resource-metadata" -}}
 {{- with .labels }}
 labels:
-  {{- toYaml . | nindent 2 }}
+  {{- include "string-map" . | nindent 2 }}
 {{- end }}
 {{- with .annotations }}
 annotations:
-  {{- toYaml . | nindent 2 }}
+  {{- include "string-map" . | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -12,6 +12,19 @@ rendered as YAML booleans or numbers.
 {{- end }}
 
 {{/*
+Fail unless a value is absent or a mapping. Used to turn mis-typed metadata values into an
+error that names the values path, instead of an opaque "range can't iterate over" further
+down the render.
+Expects a dict with "value" and "path".
+*/}}
+{{- define "assert-map" -}}
+{{- $value := .value -}}
+{{- if and (not (kindIs "invalid" $value)) (not (kindIs "map" $value)) -}}
+{{- fail (printf "%s: must be a mapping, got %s" .path (kindOf $value)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate a label or annotation key against the Kubernetes qualified name rules.
 Expects a dict with "key", "kind" (label|annotation) and "path" (the values path used in the error message).
 */}}
@@ -49,9 +62,11 @@ Expects a dict with "metadata" and "path".
 */}}
 {{- define "validate-metadata" -}}
 {{- $path := .path -}}
+{{- include "assert-map" (dict "value" .metadata "path" $path) -}}
 {{- $metadata := .metadata | default dict -}}
-{{- if kindIs "map" $metadata -}}
-{{- range $key, $value := ((index $metadata "labels") | default dict) -}}
+{{- $labels := index $metadata "labels" -}}
+{{- include "assert-map" (dict "value" $labels "path" (printf "%s.labels" $path)) -}}
+{{- range $key, $value := ($labels | default dict) -}}
 {{- include "validate-metadata-key" (dict "key" $key "kind" "label" "path" (printf "%s.labels" $path)) -}}
 {{- $rendered := printf "%v" $value -}}
 {{- if gt (len $rendered) 63 -}}
@@ -61,9 +76,10 @@ Expects a dict with "metadata" and "path".
 {{- fail (printf "%s.labels: invalid value %q for label %q: a valid label value must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" $path $rendered $key) -}}
 {{- end -}}
 {{- end -}}
-{{- range $key, $value := ((index $metadata "annotations") | default dict) -}}
+{{- $annotations := index $metadata "annotations" -}}
+{{- include "assert-map" (dict "value" $annotations "path" (printf "%s.annotations" $path)) -}}
+{{- range $key, $value := ($annotations | default dict) -}}
 {{- include "validate-metadata-key" (dict "key" $key "kind" "annotation" "path" (printf "%s.annotations" $path)) -}}
-{{- end -}}
 {{- end -}}
 {{- end }}
 
@@ -71,15 +87,15 @@ Expects a dict with "metadata" and "path".
 Validate every label and annotation map the chart can render onto resources it manages.
 */}}
 {{- define "validate-all-metadata" -}}
+{{- include "assert-map" (dict "value" .Values.resource "path" ".Values.resource") -}}
 {{- range $resource, $config := (.Values.resource | default dict) }}
-{{- if kindIs "map" $config }}
-{{- include "validate-metadata" (dict "metadata" (index $config "metadata") "path" (printf ".Values.resource.%s.metadata" $resource)) -}}
+{{- include "assert-map" (dict "value" $config "path" (printf ".Values.resource.%s" $resource)) -}}
+{{- include "validate-metadata" (dict "metadata" (index ($config | default dict) "metadata") "path" (printf ".Values.resource.%s.metadata" $resource)) -}}
 {{- end }}
-{{- end }}
-{{- $runnerPod := (index (.Values.runner | default dict) "pod") | default dict }}
-{{- if kindIs "map" $runnerPod }}
-{{- include "validate-metadata" (dict "metadata" (index $runnerPod "metadata") "path" ".Values.runner.pod.metadata") -}}
-{{- end }}
+{{- include "assert-map" (dict "value" .Values.runner "path" ".Values.runner") -}}
+{{- $runnerPod := index (.Values.runner | default dict) "pod" -}}
+{{- include "assert-map" (dict "value" $runnerPod "path" ".Values.runner.pod") -}}
+{{- include "validate-metadata" (dict "metadata" (index ($runnerPod | default dict) "metadata") "path" ".Values.runner.pod.metadata") -}}
 {{- end }}
 
 {{/*

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -1,4 +1,81 @@
 {{/*
+Render a labels or annotations map with all values coerced to strings.
+Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
+rendered as YAML booleans or numbers.
+*/}}
+{{- define "string-map" -}}
+{{- $out := dict -}}
+{{- range $k, $v := . -}}
+{{- $_ := set $out $k (printf "%v" $v) -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
+{{/*
+Validate a label or annotation key against the Kubernetes qualified name rules.
+Expects a dict with "key", "kind" (label|annotation) and "path" (the values path used in the error message).
+*/}}
+{{- define "validate-metadata-key" -}}
+{{- $key := .key -}}
+{{- $parts := splitList "/" $key -}}
+{{- $name := $key -}}
+{{- if gt (len $parts) 2 -}}
+{{- fail (printf "%s: invalid %s key %q: a qualified name must consist of an optional DNS subdomain prefix followed by a single '/'" .path .kind $key) -}}
+{{- end -}}
+{{- if eq (len $parts) 2 -}}
+{{- $prefix := index $parts 0 -}}
+{{- $name = index $parts 1 -}}
+{{- if or (eq $prefix "") (gt (len $prefix) 253) (not (regexMatch "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$" $prefix)) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- end -}}
+{{- end -}}
+{{- if or (eq $name "") (gt (len $name) 63) (not (regexMatch "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$" $name)) -}}
+{{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" .path .kind $key) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate a metadata block (dict with optional "labels" and "annotations").
+Invalid runner pod labels are only rejected once the controller creates the runner pod,
+which leaves the scale set without runners, so fail at render time instead.
+Expects a dict with "metadata" and "path".
+*/}}
+{{- define "validate-metadata" -}}
+{{- $path := .path -}}
+{{- $metadata := .metadata | default dict -}}
+{{- if kindIs "map" $metadata -}}
+{{- range $key, $value := ((index $metadata "labels") | default dict) -}}
+{{- include "validate-metadata-key" (dict "key" $key "kind" "label" "path" (printf "%s.labels" $path)) -}}
+{{- $rendered := printf "%v" $value -}}
+{{- if gt (len $rendered) 63 -}}
+{{- fail (printf "%s.labels: invalid value %q for label %q: a label value must be no more than 63 characters" $path $rendered $key) -}}
+{{- end -}}
+{{- if not (regexMatch "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" $rendered) -}}
+{{- fail (printf "%s.labels: invalid value %q for label %q: a valid label value must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" $path $rendered $key) -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $value := ((index $metadata "annotations") | default dict) -}}
+{{- include "validate-metadata-key" (dict "key" $key "kind" "annotation" "path" (printf "%s.annotations" $path)) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate every label and annotation map the chart can render onto resources it manages.
+*/}}
+{{- define "validate-all-metadata" -}}
+{{- range $resource, $config := (.Values.resource | default dict) }}
+{{- if kindIs "map" $config }}
+{{- include "validate-metadata" (dict "metadata" (index $config "metadata") "path" (printf ".Values.resource.%s.metadata" $resource)) -}}
+{{- end }}
+{{- end }}
+{{- $runnerPod := (index (.Values.runner | default dict) "pod") | default dict }}
+{{- if kindIs "map" $runnerPod }}
+{{- include "validate-metadata" (dict "metadata" (index $runnerPod "metadata") "path" ".Values.runner.pod.metadata") -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the labels for the GitHub auth secret.
 */}}
 {{- define "github-secret.labels" -}}
@@ -53,14 +130,16 @@ Reserved annotations are excluded from both levels.
 
 
 {{/*
-Takes a map of user labels and removes the ones with "actions.github.com/" prefix
+Takes a map of user labels and removes the ones with "actions.github.com/" prefix.
+Values are rendered as strings so that scalars such as `true` or `1.0` do not become
+non-string YAML values, which Kubernetes rejects for labels and annotations.
 */}}
 {{- define "apply-non-reserved-gha-labels-and-annotations" -}}
 {{- $userLabels := . -}}
 {{- $processed := dict -}}
 {{- range $key, $value := $userLabels -}}
   {{- if not (hasPrefix "actions.github.com/" $key) -}}
-    {{- $_ := set $processed $key $value -}}
+    {{- $_ := set $processed $key (printf "%v" $value) -}}
   {{- end -}}
 {{- end -}}
 {{- if not (empty $processed) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -17,24 +17,27 @@ Expects a dict with "key", "kind" (label|annotation) and "path" (the values path
 */}}
 {{- define "validate-metadata-key" -}}
 {{- $key := .key -}}
+{{- $kind := .kind -}}
+{{- $path := .path -}}
 {{- $parts := splitList "/" $key -}}
 {{- $name := $key -}}
 {{- if gt (len $parts) 2 -}}
-{{- fail (printf "%s: invalid %s key %q: a qualified name must consist of an optional DNS subdomain prefix followed by a single '/'" .path .kind $key) -}}
+{{- fail (printf "%s: invalid %s key %q: a qualified name must consist of an optional DNS subdomain prefix followed by a single '/'" $path $kind $key) -}}
 {{- end -}}
 {{- if eq (len $parts) 2 -}}
 {{- $prefix := index $parts 0 -}}
 {{- $name = index $parts 1 -}}
 {{- if or (eq $prefix "") (gt (len $prefix) 253) -}}
-{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" $path $kind $key $prefix) -}}
 {{- end -}}
 {{- range $_, $seg := splitList "." $prefix -}}
 {{- if or (eq $seg "") (gt (len $seg) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $seg)) -}}
-{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain, so each dot-separated segment must be no more than 63 characters, consist of lowercase alphanumeric characters or '-', and start and end with an alphanumeric character" $path $kind $key $prefix) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- if or (eq $name "") (gt (len $name) 63) (not (regexMatch "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$" $name)) -}}
-{{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" .path .kind $key) -}}
+{{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" $path $kind $key) -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -1,7 +1,8 @@
 {{/*
-Render a labels or annotations map with all values coerced to strings.
-Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
-rendered as YAML booleans or numbers.
+Render a single label or annotation value as a string.
+Values from a values file arrive as float64, so "%v" would turn large integers into
+scientific notation (12345678901234 -> 1.2345678901234e+13) and silently write a value the
+user never asked for. Integral floats are therefore formatted without an exponent.
 */}}
 {{- define "metadata-value" -}}
 {{- if and (kindIs "float64" .) (eq . (floor .)) -}}
@@ -11,6 +12,11 @@ rendered as YAML booleans or numbers.
 {{- end -}}
 {{- end }}
 
+{{/*
+Render a labels or annotations map with all values coerced to strings.
+Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
+rendered as YAML booleans or numbers.
+*/}}
 {{- define "string-map" -}}
 {{- $out := dict -}}
 {{- range $k, $v := . -}}

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -25,7 +25,11 @@ Expects a dict with "key", "kind" (label|annotation) and "path" (the values path
 {{- if eq (len $parts) 2 -}}
 {{- $prefix := index $parts 0 -}}
 {{- $name = index $parts 1 -}}
-{{- if or (eq $prefix "") (gt (len $prefix) 253) (not (regexMatch "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$" $prefix)) -}}
+{{- if or (eq $prefix "") (gt (len $prefix) 253) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- end -}}
+{{- range $_, $seg := splitList "." $prefix -}}
+{{- if or (eq $seg "") (gt (len $seg) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $seg)) -}}
 {{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -3,10 +3,18 @@ Render a labels or annotations map with all values coerced to strings.
 Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
 rendered as YAML booleans or numbers.
 */}}
+{{- define "metadata-value" -}}
+{{- if and (kindIs "float64" .) (eq . (floor .)) -}}
+{{- printf "%.0f" . -}}
+{{- else -}}
+{{- printf "%v" . -}}
+{{- end -}}
+{{- end }}
+
 {{- define "string-map" -}}
 {{- $out := dict -}}
 {{- range $k, $v := . -}}
-{{- $_ := set $out $k (printf "%v" $v) -}}
+{{- $_ := set $out $k (include "metadata-value" $v) -}}
 {{- end -}}
 {{- toYaml $out -}}
 {{- end }}
@@ -21,6 +29,19 @@ Expects a dict with "value" and "path".
 {{- $value := .value -}}
 {{- if and (not (kindIs "invalid" $value)) (not (kindIs "map" $value)) -}}
 {{- fail (printf "%s: must be a mapping, got %s" .path (kindOf $value)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail unless a metadata value is a scalar. A map or list would otherwise be flattened by the
+string coercion into Go's own formatting (`map[a:b]`), which is a syntactically valid but
+meaningless label or annotation, and a null would become "<nil>".
+Expects a dict with "value", "key", "kind" and "path".
+*/}}
+{{- define "assert-scalar" -}}
+{{- $value := .value -}}
+{{- if or (kindIs "map" $value) (kindIs "slice" $value) (kindIs "invalid" $value) -}}
+{{- fail (printf "%s: invalid value for %s %q: must be a scalar, got %s. Quote the value if it is meant to be a string" .path .kind .key (kindOf $value)) -}}
 {{- end -}}
 {{- end }}
 
@@ -40,13 +61,11 @@ Expects a dict with "key", "kind" (label|annotation) and "path" (the values path
 {{- if eq (len $parts) 2 -}}
 {{- $prefix := index $parts 0 -}}
 {{- $name = index $parts 1 -}}
-{{- if or (eq $prefix "") (gt (len $prefix) 253) -}}
+{{- if gt (len $prefix) 253 -}}
 {{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" $path $kind $key $prefix) -}}
 {{- end -}}
-{{- range $_, $seg := splitList "." $prefix -}}
-{{- if or (eq $seg "") (gt (len $seg) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $seg)) -}}
-{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain, so each dot-separated segment must be no more than 63 characters, consist of lowercase alphanumeric characters or '-', and start and end with an alphanumeric character" $path $kind $key $prefix) -}}
-{{- end -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" $prefix) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain, so it must consist of dot-separated segments of lowercase alphanumeric characters or '-', each starting and ending with an alphanumeric character" $path $kind $key $prefix) -}}
 {{- end -}}
 {{- end -}}
 {{- if or (eq $name "") (gt (len $name) 63) (not (regexMatch "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$" $name)) -}}
@@ -68,7 +87,8 @@ Expects a dict with "metadata" and "path".
 {{- include "assert-map" (dict "value" $labels "path" (printf "%s.labels" $path)) -}}
 {{- range $key, $value := ($labels | default dict) -}}
 {{- include "validate-metadata-key" (dict "key" $key "kind" "label" "path" (printf "%s.labels" $path)) -}}
-{{- $rendered := printf "%v" $value -}}
+{{- include "assert-scalar" (dict "value" $value "key" $key "kind" "label" "path" (printf "%s.labels" $path)) -}}
+{{- $rendered := include "metadata-value" $value -}}
 {{- if gt (len $rendered) 63 -}}
 {{- fail (printf "%s.labels: invalid value %q for label %q: a label value must be no more than 63 characters" $path $rendered $key) -}}
 {{- end -}}
@@ -80,6 +100,7 @@ Expects a dict with "metadata" and "path".
 {{- include "assert-map" (dict "value" $annotations "path" (printf "%s.annotations" $path)) -}}
 {{- range $key, $value := ($annotations | default dict) -}}
 {{- include "validate-metadata-key" (dict "key" $key "kind" "annotation" "path" (printf "%s.annotations" $path)) -}}
+{{- include "assert-scalar" (dict "value" $value "key" $key "kind" "annotation" "path" (printf "%s.annotations" $path)) -}}
 {{- end -}}
 {{- end }}
 
@@ -96,6 +117,13 @@ Validate every label and annotation map the chart can render onto resources it m
 {{- $runnerPod := index (.Values.runner | default dict) "pod" -}}
 {{- include "assert-map" (dict "value" $runnerPod "path" ".Values.runner.pod") -}}
 {{- include "validate-metadata" (dict "metadata" (index ($runnerPod | default dict) "metadata") "path" ".Values.runner.pod.metadata") -}}
+{{- $listener := .Values.listener | default dict -}}
+{{- if kindIs "map" $listener -}}
+{{- $listenerPod := index $listener "podTemplate" -}}
+{{- if kindIs "map" ($listenerPod | default dict) -}}
+{{- include "validate-metadata" (dict "metadata" (index ($listenerPod | default dict) "metadata") "path" ".Values.listener.podTemplate.metadata") -}}
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -162,7 +190,7 @@ non-string YAML values, which Kubernetes rejects for labels and annotations.
 {{- $processed := dict -}}
 {{- range $key, $value := $userLabels -}}
   {{- if not (hasPrefix "actions.github.com/" $key) -}}
-    {{- $_ := set $processed $key (printf "%v" $value) -}}
+    {{- $_ := set $processed $key (include "metadata-value" $value) -}}
   {{- end -}}
 {{- end -}}
 {{- if not (empty $processed) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/_listener_template.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_listener_template.tpl
@@ -5,9 +5,16 @@
   {{- fail ".Values.listener.podTemplate must have at least metadata or spec defined" -}}
 {{- end -}}
 {{- with $metadata -}}
+{{- $out := omit . "labels" "annotations" -}}
+{{- with .labels -}}
+{{- $_ := set $out "labels" (fromYaml (include "string-map" .)) -}}
+{{- end -}}
+{{- with .annotations -}}
+{{- $_ := set $out "annotations" (fromYaml (include "string-map" .)) -}}
+{{- end -}}
 metadata:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+  {{- toYaml $out | nindent 2 }}
+{{ end }}
 {{- with $spec -}}
 spec:
   {{- $containers := (index . "containers" | default (list)) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/autoscalingrunnserset.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/autoscalingrunnserset.yaml
@@ -1,4 +1,5 @@
 {{- $runner := (.Values.runner | default dict) }}
+{{- include "validate-all-metadata" . }}
 {{- $runnerMode := (index $runner "mode" | default "") }}
 {{- $kubeMode := (index $runner "kubernetesMode" | default dict) }}
 {{- $dind := (index $runner "dind" | default dict) }}

--- a/charts/gha-runner-scale-set-experimental/templates/githubsecret.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/githubsecret.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 {{- $usesKubernetesSecrets := or (not .Values.secretResolution) (eq .Values.secretResolution.type "kubernetes") -}}
 
 {{- if and (not $usesKubernetesSecrets) (empty .Values.auth.secretName) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/hook_extension.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/hook_extension.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 {{- $runner := (.Values.runner | default dict) -}}
 {{- $runnerMode := (index $runner "mode" | default "") -}}
 {{- $kubeMode := (index $runner "kubernetesMode" | default dict) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/kube_mode_role.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 {{- $runner := (.Values.runner | default dict) -}}
 {{- $runnerMode := (index $runner "mode" | default "") -}}
 {{- $kubeMode := (index $runner "kubernetesMode" | default dict) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/kube_mode_role_binding.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/kube_mode_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 {{- $runner := (.Values.runner | default dict) -}}
 {{- $runnerMode := (index $runner "mode" | default "") -}}
 {{- $kubeMode := (index $runner "kubernetesMode" | default dict) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/kube_mode_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/kube_mode_serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 {{- $runner := (.Values.runner | default dict) -}}
 {{- $runnerMode := (index $runner "mode" | default "") -}}
 {{- $kubeMode := (index $runner "kubernetesMode" | default dict) -}}

--- a/charts/gha-runner-scale-set-experimental/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/manager_role.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/gha-runner-scale-set-experimental/templates/manager_role_binding.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/manager_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/gha-runner-scale-set-experimental/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set-experimental/templates/no_permission_serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- include "validate-all-metadata" . }}
 {{- $runnerMode := (.Values.runner.mode | default "") -}}
 {{- if ne $runnerMode "kubernetes" -}}
 apiVersion: v1

--- a/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
+++ b/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
@@ -38,7 +38,7 @@ tests:
       namespace: "test-namespace"
     asserts:
       - failedTemplate:
-          errorMessage: '.Values.runner.pod.metadata.labels: invalid label key "Invalid.Prefix/purpose": the prefix "Invalid.Prefix" must be a DNS subdomain, so each dot-separated segment must be no more than 63 characters, consist of lowercase alphanumeric characters or ''-'', and start and end with an alphanumeric character'
+          errorMessage: '.Values.runner.pod.metadata.labels: invalid label key "Invalid.Prefix/purpose": the prefix "Invalid.Prefix" must be a DNS subdomain, so it must consist of dot-separated segments of lowercase alphanumeric characters or ''-'', each starting and ending with an alphanumeric character'
 
   - it: should fail when a resource label value is not a valid Kubernetes label value
     set:
@@ -161,3 +161,96 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: '.Values.resource.ephemeralRunner: must be a mapping, got string'
+
+  - it: should fail when a listener pod label value is invalid
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      listener:
+        podTemplate:
+          metadata:
+            labels:
+              purpose: "“true”"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.listener.podTemplate.metadata.labels: invalid value "“true”" for label "purpose": a valid label value must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character'
+
+  - it: should fail when a metadata value is a mapping instead of a scalar
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      runner:
+        pod:
+          metadata:
+            annotations:
+              nested:
+                inner: "value"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.runner.pod.metadata.annotations: invalid value for annotation "nested": must be a scalar, got map. Quote the value if it is meant to be a string'
+
+  - it: should accept a prefix segment longer than 63 characters, matching Kubernetes
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      runner:
+        pod:
+          metadata:
+            labels:
+              ? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com/purpose"
+              : "yes"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com/purpose"]
+          value: "yes"
+
+  # A listener pod template carrying both metadata and spec used to render "true" and the
+  # following "spec:" key onto the same line, producing invalid YAML.
+  - it: should render listener metadata and spec together, coercing scalar values to strings
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      listener:
+        podTemplate:
+          metadata:
+            labels:
+              listener-bool: true
+            annotations:
+              listener-int: 11
+          spec:
+            containers:
+              - name: listener
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - equal:
+          path: spec.listenerTemplate.metadata.labels.listener-bool
+          value: "true"
+      - equal:
+          path: spec.listenerTemplate.metadata.annotations.listener-int
+          value: "11"
+      - equal:
+          path: spec.listenerTemplate.spec.containers[0].name
+          value: "listener"

--- a/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
+++ b/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
@@ -38,7 +38,7 @@ tests:
       namespace: "test-namespace"
     asserts:
       - failedTemplate:
-          errorMessage: '.Values.runner.pod.metadata.labels: invalid label key "Invalid.Prefix/purpose": the prefix "Invalid.Prefix" must be a DNS subdomain of no more than 253 characters'
+          errorMessage: '.Values.runner.pod.metadata.labels: invalid label key "Invalid.Prefix/purpose": the prefix "Invalid.Prefix" must be a DNS subdomain, so each dot-separated segment must be no more than 63 characters, consist of lowercase alphanumeric characters or ''-'', and start and end with an alphanumeric character'
 
   - it: should fail when a resource label value is not a valid Kubernetes label value
     set:

--- a/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
+++ b/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
@@ -1,0 +1,112 @@
+suite: "AutoscalingRunnerSet metadata validation"
+templates:
+  - autoscalingrunnserset.yaml
+tests:
+  - it: should fail when a runner pod label value is not a valid Kubernetes label value
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      runner:
+        pod:
+          metadata:
+            labels:
+              purpose: "“true”"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.runner.pod.metadata.labels: invalid value "“true”" for label "purpose": a valid label value must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character'
+
+  - it: should fail when a runner pod label key is not a valid qualified name
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      runner:
+        pod:
+          metadata:
+            labels:
+              "Invalid.Prefix/purpose": "ci"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.runner.pod.metadata.labels: invalid label key "Invalid.Prefix/purpose": the prefix "Invalid.Prefix" must be a DNS subdomain of no more than 253 characters'
+
+  - it: should fail when a resource label value is not a valid Kubernetes label value
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      resource:
+        all:
+          metadata:
+            labels:
+              team: "not valid"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.resource.all.metadata.labels: invalid value "not valid" for label "team": a valid label value must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character'
+
+  - it: should fail when an annotation key is not a valid qualified name
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      resource:
+        all:
+          metadata:
+            annotations:
+              "invalid key": "value"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.resource.all.metadata.annotations: invalid annotation key "invalid key": the name part must be no more than 63 characters, consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character'
+
+  - it: should render scalar label and annotation values as strings
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      resource:
+        ephemeralRunner:
+          metadata:
+            labels:
+              sync-wave: 1
+            annotations:
+              enabled: true
+      runner:
+        pod:
+          metadata:
+            labels:
+              enabled: true
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["enabled"]
+          value: "true"
+      - equal:
+          path: spec.ephemeralRunnerMetadata.labels["sync-wave"]
+          value: "1"
+      - equal:
+          path: spec.ephemeralRunnerMetadata.annotations["enabled"]
+          value: "true"

--- a/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
+++ b/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
@@ -110,3 +110,54 @@ tests:
       - equal:
           path: spec.ephemeralRunnerMetadata.annotations["enabled"]
           value: "true"
+
+  - it: should fail when a metadata block is not a mapping
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      runner:
+        pod:
+          metadata: "oops"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.runner.pod.metadata: must be a mapping, got string'
+
+  - it: should fail when a labels block is not a mapping
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      resource:
+        all:
+          metadata:
+            labels: "oops"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.resource.all.metadata.labels: must be a mapping, got string'
+
+  - it: should fail when a resource entry is not a mapping
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      resource:
+        ephemeralRunner: "oops"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.resource.ephemeralRunner: must be a mapping, got string'

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -68,6 +68,19 @@ rendered as YAML booleans or numbers.
 {{- end }}
 
 {{/*
+Fail unless a value is absent or a mapping. Used to turn mis-typed metadata values into an
+error that names the values path, instead of an opaque "range can't iterate over" further
+down the render.
+Expects a dict with "value" and "path".
+*/}}
+{{- define "gha-runner-scale-set.assertMap" -}}
+{{- $value := .value -}}
+{{- if and (not (kindIs "invalid" $value)) (not (kindIs "map" $value)) -}}
+{{- fail (printf "%s: must be a mapping, got %s" .path (kindOf $value)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Validate a label or annotation key against the Kubernetes qualified name rules.
 Expects a dict with "key", "kind" (label|annotation) and "path" (the values path used in the error message).
 */}}
@@ -104,6 +117,7 @@ Expects a dict with "labels" and "path".
 */}}
 {{- define "gha-runner-scale-set.validateLabels" -}}
 {{- $path := .path -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" .labels "path" $path) -}}
 {{- range $key, $value := (.labels | default dict) -}}
 {{- include "gha-runner-scale-set.validateMetadataKey" (dict "key" $key "kind" "label" "path" $path) -}}
 {{- $rendered := printf "%v" $value -}}
@@ -122,6 +136,7 @@ Expects a dict with "annotations" and "path".
 */}}
 {{- define "gha-runner-scale-set.validateAnnotations" -}}
 {{- $path := .path -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" .annotations "path" $path) -}}
 {{- range $key, $value := (.annotations | default dict) -}}
 {{- include "gha-runner-scale-set.validateMetadataKey" (dict "key" $key "kind" "annotation" "path" $path) -}}
 {{- end -}}
@@ -133,17 +148,18 @@ Validate every label and annotation map the chart can render onto resources it m
 {{- define "gha-runner-scale-set.validateMetadata" -}}
 {{- include "gha-runner-scale-set.validateLabels" (dict "labels" .Values.labels "path" ".Values.labels") -}}
 {{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" .Values.annotations "path" ".Values.annotations") -}}
-{{- with .Values.template }}
-{{- with .metadata }}
-{{- include "gha-runner-scale-set.validateLabels" (dict "labels" .labels "path" ".Values.template.metadata.labels") -}}
-{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" .annotations "path" ".Values.template.metadata.annotations") -}}
-{{- end }}
-{{- end }}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" .Values.template "path" ".Values.template") -}}
+{{- $templateMetadata := index (.Values.template | default dict) "metadata" -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" $templateMetadata "path" ".Values.template.metadata") -}}
+{{- $templateMetadata = $templateMetadata | default dict -}}
+{{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $templateMetadata "labels") "path" ".Values.template.metadata.labels") -}}
+{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $templateMetadata "annotations") "path" ".Values.template.metadata.annotations") -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" .Values.resourceMeta "path" ".Values.resourceMeta") -}}
 {{- range $resource, $meta := (.Values.resourceMeta | default dict) }}
-{{- if kindIs "map" $meta }}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" $meta "path" (printf ".Values.resourceMeta.%s" $resource)) -}}
+{{- $meta = $meta | default dict -}}
 {{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $meta "labels") "path" (printf ".Values.resourceMeta.%s.labels" $resource)) -}}
 {{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $meta "annotations") "path" (printf ".Values.resourceMeta.%s.annotations" $resource)) -}}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -81,7 +81,11 @@ Expects a dict with "key", "kind" (label|annotation) and "path" (the values path
 {{- if eq (len $parts) 2 -}}
 {{- $prefix := index $parts 0 -}}
 {{- $name = index $parts 1 -}}
-{{- if or (eq $prefix "") (gt (len $prefix) 253) (not (regexMatch "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$" $prefix)) -}}
+{{- if or (eq $prefix "") (gt (len $prefix) 253) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- end -}}
+{{- range $_, $seg := splitList "." $prefix -}}
+{{- if or (eq $seg "") (gt (len $seg) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $seg)) -}}
 {{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -73,24 +73,27 @@ Expects a dict with "key", "kind" (label|annotation) and "path" (the values path
 */}}
 {{- define "gha-runner-scale-set.validateMetadataKey" -}}
 {{- $key := .key -}}
+{{- $kind := .kind -}}
+{{- $path := .path -}}
 {{- $parts := splitList "/" $key -}}
 {{- $name := $key -}}
 {{- if gt (len $parts) 2 -}}
-{{- fail (printf "%s: invalid %s key %q: a qualified name must consist of an optional DNS subdomain prefix followed by a single '/'" .path .kind $key) -}}
+{{- fail (printf "%s: invalid %s key %q: a qualified name must consist of an optional DNS subdomain prefix followed by a single '/'" $path $kind $key) -}}
 {{- end -}}
 {{- if eq (len $parts) 2 -}}
 {{- $prefix := index $parts 0 -}}
 {{- $name = index $parts 1 -}}
 {{- if or (eq $prefix "") (gt (len $prefix) 253) -}}
-{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" $path $kind $key $prefix) -}}
 {{- end -}}
 {{- range $_, $seg := splitList "." $prefix -}}
 {{- if or (eq $seg "") (gt (len $seg) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $seg)) -}}
-{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain, so each dot-separated segment must be no more than 63 characters, consist of lowercase alphanumeric characters or '-', and start and end with an alphanumeric character" $path $kind $key $prefix) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- if or (eq $name "") (gt (len $name) 63) (not (regexMatch "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$" $name)) -}}
-{{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" .path .kind $key) -}}
+{{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" $path $kind $key) -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -55,16 +55,102 @@ app.kubernetes.io/instance: {{ include "gha-runner-scale-set.scale-set-name" . }
 {{- end }}
 
 {{/*
+Render a labels or annotations map with all values coerced to strings.
+Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
+rendered as YAML booleans or numbers.
+*/}}
+{{- define "gha-runner-scale-set.stringMap" -}}
+{{- $out := dict -}}
+{{- range $k, $v := . -}}
+{{- $_ := set $out $k (printf "%v" $v) -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
+{{/*
+Validate a label or annotation key against the Kubernetes qualified name rules.
+Expects a dict with "key", "kind" (label|annotation) and "path" (the values path used in the error message).
+*/}}
+{{- define "gha-runner-scale-set.validateMetadataKey" -}}
+{{- $key := .key -}}
+{{- $parts := splitList "/" $key -}}
+{{- $name := $key -}}
+{{- if gt (len $parts) 2 -}}
+{{- fail (printf "%s: invalid %s key %q: a qualified name must consist of an optional DNS subdomain prefix followed by a single '/'" .path .kind $key) -}}
+{{- end -}}
+{{- if eq (len $parts) 2 -}}
+{{- $prefix := index $parts 0 -}}
+{{- $name = index $parts 1 -}}
+{{- if or (eq $prefix "") (gt (len $prefix) 253) (not (regexMatch "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$" $prefix)) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" .path .kind $key $prefix) -}}
+{{- end -}}
+{{- end -}}
+{{- if or (eq $name "") (gt (len $name) 63) (not (regexMatch "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$" $name)) -}}
+{{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" .path .kind $key) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate a map of labels. Invalid labels are only rejected once the controller creates the
+runner pod, which leaves the scale set without runners, so fail at render time instead.
+Expects a dict with "labels" and "path".
+*/}}
+{{- define "gha-runner-scale-set.validateLabels" -}}
+{{- $path := .path -}}
+{{- range $key, $value := (.labels | default dict) -}}
+{{- include "gha-runner-scale-set.validateMetadataKey" (dict "key" $key "kind" "label" "path" $path) -}}
+{{- $rendered := printf "%v" $value -}}
+{{- if gt (len $rendered) 63 -}}
+{{- fail (printf "%s: invalid value %q for label %q: a label value must be no more than 63 characters" $path $rendered $key) -}}
+{{- end -}}
+{{- if not (regexMatch "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$" $rendered) -}}
+{{- fail (printf "%s: invalid value %q for label %q: a valid label value must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" $path $rendered $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate a map of annotations. Annotation values are unconstrained, so only keys are validated.
+Expects a dict with "annotations" and "path".
+*/}}
+{{- define "gha-runner-scale-set.validateAnnotations" -}}
+{{- $path := .path -}}
+{{- range $key, $value := (.annotations | default dict) -}}
+{{- include "gha-runner-scale-set.validateMetadataKey" (dict "key" $key "kind" "annotation" "path" $path) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate every label and annotation map the chart can render onto resources it manages.
+*/}}
+{{- define "gha-runner-scale-set.validateMetadata" -}}
+{{- include "gha-runner-scale-set.validateLabels" (dict "labels" .Values.labels "path" ".Values.labels") -}}
+{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" .Values.annotations "path" ".Values.annotations") -}}
+{{- with .Values.template }}
+{{- with .metadata }}
+{{- include "gha-runner-scale-set.validateLabels" (dict "labels" .labels "path" ".Values.template.metadata.labels") -}}
+{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" .annotations "path" ".Values.template.metadata.annotations") -}}
+{{- end }}
+{{- end }}
+{{- range $resource, $meta := (.Values.resourceMeta | default dict) }}
+{{- if kindIs "map" $meta }}
+{{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $meta "labels") "path" (printf ".Values.resourceMeta.%s.labels" $resource)) -}}
+{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $meta "annotations") "path" (printf ".Values.resourceMeta.%s.annotations" $resource)) -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Render a ResourceMeta block for AutoscalingRunnerSet spec fields.
 */}}
 {{- define "gha-runner-scale-set.resourceMetaSpec" -}}
 {{- with .labels }}
 labels:
-  {{- toYaml . | nindent 2 }}
+  {{- include "gha-runner-scale-set.stringMap" . | nindent 2 }}
 {{- end }}
 {{- with .annotations }}
 annotations:
-  {{- toYaml . | nindent 2 }}
+  {{- include "gha-runner-scale-set.stringMap" . | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -55,6 +55,20 @@ app.kubernetes.io/instance: {{ include "gha-runner-scale-set.scale-set-name" . }
 {{- end }}
 
 {{/*
+Render a single label or annotation value as a string.
+Values from a values file arrive as float64, so "%v" would turn large integers into
+scientific notation (12345678901234 -> 1.2345678901234e+13) and silently write a value the
+user never asked for. Integral floats are therefore formatted without an exponent.
+*/}}
+{{- define "gha-runner-scale-set.metadataValue" -}}
+{{- if and (kindIs "float64" .) (eq . (floor .)) -}}
+{{- printf "%.0f" . -}}
+{{- else -}}
+{{- printf "%v" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Render a labels or annotations map with all values coerced to strings.
 Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
 rendered as YAML booleans or numbers.
@@ -62,7 +76,7 @@ rendered as YAML booleans or numbers.
 {{- define "gha-runner-scale-set.stringMap" -}}
 {{- $out := dict -}}
 {{- range $k, $v := . -}}
-{{- $_ := set $out $k (printf "%v" $v) -}}
+{{- $_ := set $out $k (include "gha-runner-scale-set.metadataValue" $v) -}}
 {{- end -}}
 {{- toYaml $out -}}
 {{- end }}
@@ -96,17 +110,28 @@ Expects a dict with "key", "kind" (label|annotation) and "path" (the values path
 {{- if eq (len $parts) 2 -}}
 {{- $prefix := index $parts 0 -}}
 {{- $name = index $parts 1 -}}
-{{- if or (eq $prefix "") (gt (len $prefix) 253) -}}
+{{- if gt (len $prefix) 253 -}}
 {{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain of no more than 253 characters" $path $kind $key $prefix) -}}
 {{- end -}}
-{{- range $_, $seg := splitList "." $prefix -}}
-{{- if or (eq $seg "") (gt (len $seg) 63) (not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $seg)) -}}
-{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain, so each dot-separated segment must be no more than 63 characters, consist of lowercase alphanumeric characters or '-', and start and end with an alphanumeric character" $path $kind $key $prefix) -}}
-{{- end -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$" $prefix) -}}
+{{- fail (printf "%s: invalid %s key %q: the prefix %q must be a DNS subdomain, so it must consist of dot-separated segments of lowercase alphanumeric characters or '-', each starting and ending with an alphanumeric character" $path $kind $key $prefix) -}}
 {{- end -}}
 {{- end -}}
 {{- if or (eq $name "") (gt (len $name) 63) (not (regexMatch "^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$" $name)) -}}
 {{- fail (printf "%s: invalid %s key %q: the name part must be no more than 63 characters, consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character" $path $kind $key) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail unless a metadata value is a scalar. A map or list would otherwise be flattened by the
+string coercion into Go's own formatting (`map[a:b]`), which is a syntactically valid but
+meaningless label or annotation, and a null would become "<nil>".
+Expects a dict with "value", "key", "kind" and "path".
+*/}}
+{{- define "gha-runner-scale-set.assertScalar" -}}
+{{- $value := .value -}}
+{{- if or (kindIs "map" $value) (kindIs "slice" $value) (kindIs "invalid" $value) -}}
+{{- fail (printf "%s: invalid value for %s %q: must be a scalar, got %s. Quote the value if it is meant to be a string" .path .kind .key (kindOf $value)) -}}
 {{- end -}}
 {{- end }}
 
@@ -120,7 +145,8 @@ Expects a dict with "labels" and "path".
 {{- include "gha-runner-scale-set.assertMap" (dict "value" .labels "path" $path) -}}
 {{- range $key, $value := (.labels | default dict) -}}
 {{- include "gha-runner-scale-set.validateMetadataKey" (dict "key" $key "kind" "label" "path" $path) -}}
-{{- $rendered := printf "%v" $value -}}
+{{- include "gha-runner-scale-set.assertScalar" (dict "value" $value "key" $key "kind" "label" "path" $path) -}}
+{{- $rendered := include "gha-runner-scale-set.metadataValue" $value -}}
 {{- if gt (len $rendered) 63 -}}
 {{- fail (printf "%s: invalid value %q for label %q: a label value must be no more than 63 characters" $path $rendered $key) -}}
 {{- end -}}
@@ -139,6 +165,7 @@ Expects a dict with "annotations" and "path".
 {{- include "gha-runner-scale-set.assertMap" (dict "value" .annotations "path" $path) -}}
 {{- range $key, $value := (.annotations | default dict) -}}
 {{- include "gha-runner-scale-set.validateMetadataKey" (dict "key" $key "kind" "annotation" "path" $path) -}}
+{{- include "gha-runner-scale-set.assertScalar" (dict "value" $value "key" $key "kind" "annotation" "path" $path) -}}
 {{- end -}}
 {{- end }}
 
@@ -154,6 +181,12 @@ Validate every label and annotation map the chart can render onto resources it m
 {{- $templateMetadata = $templateMetadata | default dict -}}
 {{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $templateMetadata "labels") "path" ".Values.template.metadata.labels") -}}
 {{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $templateMetadata "annotations") "path" ".Values.template.metadata.annotations") -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" .Values.listenerTemplate "path" ".Values.listenerTemplate") -}}
+{{- $listenerMetadata := index (.Values.listenerTemplate | default dict) "metadata" -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" $listenerMetadata "path" ".Values.listenerTemplate.metadata") -}}
+{{- $listenerMetadata = $listenerMetadata | default dict -}}
+{{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $listenerMetadata "labels") "path" ".Values.listenerTemplate.metadata.labels") -}}
+{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $listenerMetadata "annotations") "path" ".Values.listenerTemplate.metadata.annotations") -}}
 {{- include "gha-runner-scale-set.assertMap" (dict "value" .Values.resourceMeta "path" ".Values.resourceMeta") -}}
 {{- range $resource, $meta := (.Values.resourceMeta | default dict) }}
 {{- include "gha-runner-scale-set.assertMap" (dict "value" $meta "path" (printf ".Values.resourceMeta.%s" $resource)) -}}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -28,7 +28,7 @@ metadata:
     {{- with .Values.resourceMeta.autoscalingRunnerSet.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -39,7 +39,7 @@ metadata:
     {{- with .Values.annotations }}
     {{- range $k, $v := . }}
     {{- if not (or (hasPrefix "actions.github.com/cleanup-" $k) (eq $k "actions.github.com/values-hash")) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -47,7 +47,7 @@ metadata:
     {{- with .Values.resourceMeta.autoscalingRunnerSet.annotations }}
     {{- range $k, $v := . }}
     {{- if not (or (hasPrefix "actions.github.com/cleanup-" $k) (eq $k "actions.github.com/values-hash")) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -161,7 +161,23 @@ spec:
 
   {{- with .Values.listenerTemplate }}
   listenerTemplate:
+    {{- with .metadata }}
+    metadata:
+      {{- with .labels }}
+      labels:
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
+      {{- end }}
+      {{- with .annotations }}
+      annotations:
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
+      {{- end }}
+      {{- with omit . "labels" "annotations" }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+    {{- with omit . "metadata" }}
     {{- toYaml . | nindent 4}}
+    {{- end }}
   {{- end }}
 
   {{- with .Values.listenerMetrics }}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -1,6 +1,7 @@
 {{- $resourceMeta := default (dict) .Values.resourceMeta }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.autoscalingRunnerSet) }}
 {{- /* .Values.listenerConfig is validated by values.schema.json */ -}}
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 apiVersion: actions.github.com/v1alpha1
 kind: AutoscalingRunnerSet
 metadata:
@@ -218,11 +219,11 @@ spec:
     metadata:
       {{- with .labels }}
       labels:
-        {{- toYaml . | nindent 8 }}
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
       {{- end }}
       {{- with .annotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
       {{- end }}
     {{- end }}
     spec:

--- a/charts/gha-runner-scale-set/templates/githubsecret.yaml
+++ b/charts/gha-runner-scale-set/templates/githubsecret.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- if not (kindIs "string" .Values.githubConfigSecret) }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.githubConfigSecret) }}
 apiVersion: v1

--- a/charts/gha-runner-scale-set/templates/githubsecret.yaml
+++ b/charts/gha-runner-scale-set/templates/githubsecret.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/templates/githubsecret.yaml
+++ b/charts/gha-runner-scale-set/templates/githubsecret.yaml
@@ -18,17 +18,17 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.githubConfigSecret.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.githubConfigSecret.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- $containerMode := .Values.containerMode }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.kubernetesModeRole) }}
 {{- if and (or (eq $containerMode.type "kubernetes") (eq $containerMode.type "kubernetes-novolume")) (not .Values.template.spec.serviceAccountName) }}

--- a/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
@@ -20,17 +20,17 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRole.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRole.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
@@ -19,18 +19,18 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRoleBinding.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
 
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRoleBinding.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- $containerMode := .Values.containerMode }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.kubernetesModeRoleBinding) }}
 {{- if and (or (eq $containerMode.type "kubernetes") (eq $containerMode.type "kubernetes-novolume")) (not .Values.template.spec.serviceAccountName) }}

--- a/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- $containerMode := .Values.containerMode }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.kubernetesModeServiceAccount) }}
 {{- if and (or (eq $containerMode.type "kubernetes") (eq $containerMode.type "kubernetes-novolume")) (not .Values.template.spec.serviceAccountName) }}

--- a/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
@@ -9,11 +9,11 @@ metadata:
   {{- if or .Values.annotations $hasCustomResourceMeta }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeServiceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   {{- end }}
@@ -30,7 +30,7 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeServiceAccount.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}

--- a/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
@@ -25,7 +25,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role.yaml
@@ -17,18 +17,18 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRole.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager-role
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRole.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.managerRole) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/gha-runner-scale-set/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.managerRoleBinding) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
@@ -17,18 +17,18 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRoleBinding.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager-role-binding
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRoleBinding.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- include "gha-runner-scale-set.validateMetadata" . }}
 {{- $hasCustomResourceMeta := (and .Values.resourceMeta .Values.resourceMeta.noPermissionServiceAccount) }}
 {{- $containerMode := .Values.containerMode }}
 {{- if and (ne $containerMode.type "kubernetes") (ne $containerMode.type "kubernetes-novolume") (not .Values.template.spec.serviceAccountName) }}

--- a/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
@@ -19,17 +19,17 @@ metadata:
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.noPermissionServiceAccount.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.noPermissionServiceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -3398,7 +3398,7 @@ func TestTemplateRenderedAutoScalingRunnerSet_ListenerMetadataIsValidated(t *tes
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
 
-	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+	_, err = helm.RenderTemplateContextE(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `.Values.listenerTemplate.metadata.labels: invalid value "“true”" for label "purpose"`)
 }
@@ -3426,7 +3426,7 @@ func TestTemplateRenderedAutoScalingRunnerSet_NonScalarMetadataValueValidationEr
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
 
-	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+	_, err = helm.RenderTemplateContextE(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `.Values.template.metadata.annotations: invalid value for annotation "nested": must be a scalar, got map`)
 }

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -2684,7 +2684,7 @@ func TestCustomLabels(t *testing.T) {
 			"controllerServiceAccount.name":                                "arc",
 			"containerMode.type":                                           "kubernetes",
 			"controllerServiceAccount.namespace":                           "arc-system",
-			`labels.argocd\.argoproj\.io/sync-wave`:                        `"1"`,
+			`labels.argocd\.argoproj\.io/sync-wave`:                        "1",
 			`labels.app\.kubernetes\.io/part-of`:                           "no-override", // this shouldn't be overwritten
 			"resourceMeta.autoscalingRunnerSet.labels.ars-custom":          "ars-custom-value",
 			"resourceMeta.githubConfigSecret.labels.gh-custom":             "gh-custom-value",
@@ -2708,7 +2708,7 @@ func TestCustomLabels(t *testing.T) {
 	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/githubsecret.yaml"})
 
 	const targetLabel = "argocd.argoproj.io/sync-wave"
-	const wantCustomValue = `"1"`
+	const wantCustomValue = "1"
 	const reservedLabel = "app.kubernetes.io/part-of"
 	const wantReservedValue = "gha-rs"
 
@@ -2783,7 +2783,7 @@ func TestCustomLabels(t *testing.T) {
 			"githubConfigSecret.github_token":                            "gh_token12345",
 			"controllerServiceAccount.name":                              "arc",
 			"controllerServiceAccount.namespace":                         "arc-system",
-			`labels.argocd\.argoproj\.io/sync-wave`:                      `"1"`,
+			`labels.argocd\.argoproj\.io/sync-wave`:                      "1",
 			"resourceMeta.noPermissionServiceAccount.labels.npsa-custom": "npsa-custom-value",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
@@ -2815,7 +2815,7 @@ func TestCustomAnnotations(t *testing.T) {
 			"containerMode.type":                                                "kubernetes",
 			"controllerServiceAccount.name":                                     "arc",
 			"controllerServiceAccount.namespace":                                "arc-system",
-			`annotations.argocd\.argoproj\.io/sync-wave`:                        `"1"`,
+			`annotations.argocd\.argoproj\.io/sync-wave`:                        "1",
 			"resourceMeta.autoscalingRunnerSet.annotations.ars-custom":          "ars-custom-value",
 			"resourceMeta.githubConfigSecret.annotations.gh-custom":             "gh-custom-value",
 			"resourceMeta.kubernetesModeRole.annotations.kmr-custom":            "kmr-custom-value",
@@ -2836,7 +2836,7 @@ func TestCustomAnnotations(t *testing.T) {
 	}
 
 	const targetAnnotations = "argocd.argoproj.io/sync-wave"
-	const wantCustomValue = `"1"`
+	const wantCustomValue = "1"
 
 	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/githubsecret.yaml"})
 
@@ -2904,7 +2904,7 @@ func TestCustomAnnotations(t *testing.T) {
 			"githubConfigSecret.github_token":                                 "gh_token12345",
 			"controllerServiceAccount.name":                                   "arc",
 			"controllerServiceAccount.namespace":                              "arc-system",
-			`annotations.argocd\.argoproj\.io/sync-wave`:                      `"1"`,
+			`annotations.argocd\.argoproj\.io/sync-wave`:                      "1",
 			"resourceMeta.noPermissionServiceAccount.annotations.npsa-custom": "npsa-custom-value",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
@@ -3151,4 +3151,108 @@ func TestAutoscalingRunnerSetCustomAnnotationsAndLabelsApplied(t *testing.T) {
 
 	assert.NotEqual(t, "not-propagated", autoscalingRunnerSet.Annotations["actions.github.com/cleanup-manager-role-name"])
 	assert.NotEqual(t, "not-propagated", autoscalingRunnerSet.Labels["app.kubernetes.io/component"])
+}
+
+func TestTemplateRenderedAutoScalingRunnerSet_InvalidMetadataValidationError(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	tt := map[string]struct {
+		key           string
+		value         string
+		expectedError string
+	}{
+		"runner pod label with smart quotes": {
+			key:           "template.metadata.labels.custom",
+			value:         "\u201ctrue\u201d",
+			expectedError: `.Values.template.metadata.labels: invalid value "“true”" for label "custom"`,
+		},
+		"runner pod label value too long": {
+			key:           "template.metadata.labels.custom",
+			value:         strings.Repeat("a", 64),
+			expectedError: `.Values.template.metadata.labels: invalid value "` + strings.Repeat("a", 64) + `" for label "custom": a label value must be no more than 63 characters`,
+		},
+		"runner pod label key with invalid prefix": {
+			key:           "template.metadata.labels.Invalid\\.Prefix/custom",
+			value:         "value",
+			expectedError: `.Values.template.metadata.labels: invalid label key "Invalid.Prefix/custom"`,
+		},
+		"runner pod annotation key invalid": {
+			key:           "template.metadata.annotations.invalid key",
+			value:         "value",
+			expectedError: `.Values.template.metadata.annotations: invalid annotation key "invalid key"`,
+		},
+		"chart level label invalid": {
+			key:           "labels.custom",
+			value:         "not valid",
+			expectedError: `.Values.labels: invalid value "not valid" for label "custom"`,
+		},
+		"resource meta label invalid": {
+			key:           "resourceMeta.ephemeralRunner.labels.custom",
+			value:         "not valid",
+			expectedError: `.Values.resourceMeta.ephemeralRunner.labels: invalid value "not valid" for label "custom"`,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			releaseName := "test-runners"
+			namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+			options := &helm.Options{
+				Logger: logger.Discard,
+				SetValues: map[string]string{
+					"githubConfigUrl":                    "https://github.com/actions",
+					"githubConfigSecret.github_token":    "gh_token12345",
+					"controllerServiceAccount.name":      "arc",
+					"controllerServiceAccount.namespace": "arc-system",
+					tc.key:                               tc.value,
+				},
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+			}
+
+			_, err := helm.RenderTemplateContextE(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.expectedError)
+		})
+	}
+}
+
+func TestTemplateRenderedAutoScalingRunnerSet_ValidMetadataIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"githubConfigUrl":                                "https://github.com/actions",
+			"githubConfigSecret.github_token":                "gh_token12345",
+			"controllerServiceAccount.name":                  "arc",
+			"controllerServiceAccount.namespace":             "arc-system",
+			"template.metadata.labels.custom":                "true",
+			"template.metadata.labels.example\\.com/custom":  "value_1.0-rc",
+			"template.metadata.labels.empty":                 "",
+			"template.metadata.annotations.example\\.com/an": "any value is allowed: ✅",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var autoscalingRunnerSet v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &autoscalingRunnerSet)
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Labels["custom"])
+	assert.Equal(t, "value_1.0-rc", autoscalingRunnerSet.Spec.Template.Labels["example.com/custom"])
+	assert.Equal(t, "", autoscalingRunnerSet.Spec.Template.Labels["empty"])
+	assert.Equal(t, "any value is allowed: ✅", autoscalingRunnerSet.Spec.Template.Annotations["example.com/an"])
 }

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -3289,11 +3289,18 @@ func TestTemplateRenderedAutoScalingRunnerSet_ScalarMetadataValuesAreRenderedAsS
 	assert.Equal(t, "1", autoscalingRunnerSet.Labels["chart-int"])
 	assert.Equal(t, "false", autoscalingRunnerSet.Annotations["chart-bool-annotation"])
 	assert.Equal(t, "1.5", autoscalingRunnerSet.Annotations["chart-float-annotation"])
+	assert.Equal(t, "12345678901234", autoscalingRunnerSet.Annotations["chart-big-int-annotation"])
 
 	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Labels["pod-bool"])
 	assert.Equal(t, "42", autoscalingRunnerSet.Spec.Template.Labels["pod-int"])
 	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Annotations["pod-bool-annotation"])
 	assert.Equal(t, "7", autoscalingRunnerSet.Spec.Template.Annotations["pod-int-annotation"])
+
+	require.NotNil(t, autoscalingRunnerSet.Spec.ListenerTemplate)
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.ListenerTemplate.Labels["listener-bool"])
+	assert.Equal(t, "11", autoscalingRunnerSet.Spec.ListenerTemplate.Annotations["listener-int-annotation"])
+	require.Len(t, autoscalingRunnerSet.Spec.ListenerTemplate.Spec.Containers, 1)
+	assert.Equal(t, "listener", autoscalingRunnerSet.Spec.ListenerTemplate.Spec.Containers[0].Name)
 
 	require.NotNil(t, autoscalingRunnerSet.Spec.EphemeralRunnerMetadata)
 	assert.Equal(t, "false", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-bool"])
@@ -3336,6 +3343,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_NonMapMetadataValidationError(t *t
 			value:         "oops",
 			expectedError: ".Values.resourceMeta.githubConfigSecret: must be a mapping, got string",
 		},
+		"listener metadata is not a map": {
+			key:           "listenerTemplate.metadata",
+			value:         "oops",
+			expectedError: ".Values.listenerTemplate.metadata: must be a mapping, got string",
+		},
 	}
 
 	for name, tc := range tt {
@@ -3362,4 +3374,92 @@ func TestTemplateRenderedAutoScalingRunnerSet_NonMapMetadataValidationError(t *t
 			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
+}
+
+func TestTemplateRenderedAutoScalingRunnerSet_ListenerMetadataIsValidated(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"githubConfigUrl":                          "https://github.com/actions",
+			"githubConfigSecret.github_token":          "gh_token12345",
+			"controllerServiceAccount.name":            "arc",
+			"controllerServiceAccount.namespace":       "arc-system",
+			"listenerTemplate.metadata.labels.purpose": "“true”",
+			"listenerTemplate.spec.containers[0].name": "listener",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `.Values.listenerTemplate.metadata.labels: invalid value "“true”" for label "purpose"`)
+}
+
+func TestTemplateRenderedAutoScalingRunnerSet_NonScalarMetadataValueValidationError(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"githubConfigUrl":                    "https://github.com/actions",
+			"githubConfigSecret.github_token":    "gh_token12345",
+			"controllerServiceAccount.name":      "arc",
+			"controllerServiceAccount.namespace": "arc-system",
+		},
+		SetJsonValues: map[string]string{
+			"template.metadata.annotations": `{"nested":{"inner":"value"}}`,
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `.Values.template.metadata.annotations: invalid value for annotation "nested": must be a scalar, got map`)
+}
+
+// Kubernetes only bounds a label key prefix at 253 characters in total, so the chart must
+// not impose the stricter per-segment 63 character limit that applies to DNS labels.
+func TestTemplateRenderedAutoScalingRunnerSet_LongPrefixSegmentIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	key := strings.Repeat("a", 64) + ".example.com/purpose"
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"githubConfigUrl":                                                "https://github.com/actions",
+			"githubConfigSecret.github_token":                                "gh_token12345",
+			"controllerServiceAccount.name":                                  "arc",
+			"controllerServiceAccount.namespace":                             "arc-system",
+			"template.metadata.labels." + strings.ReplaceAll(key, ".", `\.`): "yes",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var autoscalingRunnerSet v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &autoscalingRunnerSet)
+
+	assert.Equal(t, "yes", autoscalingRunnerSet.Spec.Template.Labels[key])
 }

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -3256,3 +3256,110 @@ func TestTemplateRenderedAutoScalingRunnerSet_ValidMetadataIsAccepted(t *testing
 	assert.Equal(t, "", autoscalingRunnerSet.Spec.Template.Labels["empty"])
 	assert.Equal(t, "any value is allowed: ✅", autoscalingRunnerSet.Spec.Template.Annotations["example.com/an"])
 }
+
+// Kubernetes only accepts string label and annotation values. Values supplied as unquoted
+// YAML scalars parse as bools/numbers, so the chart has to coerce them when rendering.
+// SetValues always yields strings, so this has to come from a values file to be meaningful.
+func TestTemplateRenderedAutoScalingRunnerSet_ScalarMetadataValuesAreRenderedAsStrings(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	testValuesPath, err := filepath.Abs("../tests/values_scalar_metadata.yaml")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger:         logger.Discard,
+		ValuesFiles:    []string{testValuesPath},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	// UnmarshalK8SYaml fails outright if a value decodes as a bool or number rather than a
+	// string, so a successful decode is itself part of the assertion.
+	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var autoscalingRunnerSet v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &autoscalingRunnerSet)
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Labels["chart-bool"])
+	assert.Equal(t, "1", autoscalingRunnerSet.Labels["chart-int"])
+	assert.Equal(t, "false", autoscalingRunnerSet.Annotations["chart-bool-annotation"])
+	assert.Equal(t, "1.5", autoscalingRunnerSet.Annotations["chart-float-annotation"])
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Labels["pod-bool"])
+	assert.Equal(t, "42", autoscalingRunnerSet.Spec.Template.Labels["pod-int"])
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Annotations["pod-bool-annotation"])
+	assert.Equal(t, "7", autoscalingRunnerSet.Spec.Template.Annotations["pod-int-annotation"])
+
+	require.NotNil(t, autoscalingRunnerSet.Spec.EphemeralRunnerMetadata)
+	assert.Equal(t, "false", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-bool"])
+	assert.Equal(t, "3", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-int"])
+	assert.Equal(t, "9", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Annotations["runner-int-annotation"])
+
+	output = helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/githubsecret.yaml"})
+
+	var githubSecret corev1.Secret
+	helm.UnmarshalK8SYaml(t, output, &githubSecret)
+
+	assert.Equal(t, "5", githubSecret.Labels["secret-int"])
+	assert.Equal(t, "true", githubSecret.Labels["chart-bool"])
+	assert.Equal(t, "1.5", githubSecret.Annotations["chart-float-annotation"])
+}
+
+func TestTemplateRenderedAutoScalingRunnerSet_NonMapMetadataValidationError(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	tt := map[string]struct {
+		key           string
+		value         string
+		expectedError string
+	}{
+		"chart labels is not a map": {
+			key:           "labels",
+			value:         "oops",
+			expectedError: ".Values.labels: must be a mapping, got string",
+		},
+		"runner pod labels is not a map": {
+			key:           "template.metadata.labels",
+			value:         "oops",
+			expectedError: ".Values.template.metadata.labels: must be a mapping, got string",
+		},
+		"resourceMeta entry is not a map": {
+			key:           "resourceMeta.githubConfigSecret",
+			value:         "oops",
+			expectedError: ".Values.resourceMeta.githubConfigSecret: must be a mapping, got string",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			releaseName := "test-runners"
+			namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+			options := &helm.Options{
+				Logger: logger.Discard,
+				SetValues: map[string]string{
+					"githubConfigUrl":                    "https://github.com/actions",
+					"githubConfigSecret.github_token":    "gh_token12345",
+					"controllerServiceAccount.name":      "arc",
+					"controllerServiceAccount.namespace": "arc-system",
+					tc.key:                               tc.value,
+				},
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+			}
+
+			_, err := helm.RenderTemplateContextE(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.expectedError)
+		})
+	}
+}

--- a/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
+++ b/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
@@ -1,0 +1,36 @@
+githubConfigUrl: https://github.com/actions
+githubConfigSecret:
+  github_token: gh_token12345
+controllerServiceAccount:
+  name: arc
+  namespace: arc-system
+
+# Every value below is an unquoted YAML scalar, so it parses as a bool, int or float
+# rather than a string. Kubernetes only accepts string label and annotation values, so
+# the chart has to coerce these when rendering.
+labels:
+  chart-bool: true
+  chart-int: 1
+annotations:
+  chart-bool-annotation: false
+  chart-float-annotation: 1.5
+
+template:
+  metadata:
+    labels:
+      pod-bool: true
+      pod-int: 42
+    annotations:
+      pod-bool-annotation: true
+      pod-int-annotation: 7
+
+resourceMeta:
+  ephemeralRunner:
+    labels:
+      runner-bool: false
+      runner-int: 3
+    annotations:
+      runner-int-annotation: 9
+  githubConfigSecret:
+    labels:
+      secret-int: 5

--- a/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
+++ b/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
@@ -14,6 +14,9 @@ labels:
 annotations:
   chart-bool-annotation: false
   chart-float-annotation: 1.5
+  # Large integers must not be rendered in scientific notation. Values loaded from a file
+  # arrive as float64, so a naive "%v" would produce "1.2345678901234e+13".
+  chart-big-int-annotation: 12345678901234
 
 template:
   metadata:
@@ -34,3 +37,13 @@ resourceMeta:
   githubConfigSecret:
     labels:
       secret-int: 5
+
+listenerTemplate:
+  metadata:
+    labels:
+      listener-bool: true
+    annotations:
+      listener-int-annotation: 11
+  spec:
+    containers:
+      - name: listener


### PR DESCRIPTION
Fixes #4372

## The problem

An invalid label value supplied through `.Values.template.metadata.labels` is not rejected anywhere until the controller tries to create the runner pod. In the linked issue the value was `“true”` — a `true` that had been through WordPad, so it carried smart quotes.

The path is unvalidated end to end:

1. `.Values.template.metadata.labels` renders into `AutoscalingRunnerSet.spec.template.metadata.labels`. The CRD schema only enforces `type: string`, not label syntax, so the API server accepts it.
2. It flows into `EphemeralRunnerSpec.Labels` and is merged onto the pod in `newEphemeralRunnerPod`.
3. The Pod create is the first thing that validates it. `ephemeralrunner_controller.go` treats `IsInvalid` as unrecoverable and calls `markAsFailed` with `ReasonInvalidPodFailure`.

Every ephemeral runner fails and no pods are ever spawned, with only the pod-level error in the controller logs and nothing pointing back at the values file. Reinstalling the chart, deleting the CRDs, or recreating namespaces cannot help, because the bad value is in the user's values and gets re-applied every time. The reporter went through all of that before eventually finding the smart quotes by hand.

## The fix

- Validate every label and annotation map the charts render, before the `AutoscalingRunnerSet` is emitted: keys against the Kubernetes qualified-name rules, label values against the label value regex and the 63 character limit. `helm install`/`helm upgrade` now fails immediately, naming the values path, the key and the offending value.
- Render all metadata values as strings. They were previously emitted with raw `toYaml`, so `enabled: true` or `sync-wave: 1` became a YAML boolean or number, which Kubernetes rejects for labels and annotations. This is the same class of bug, just reached from the other direction.

Both changes are applied to `gha-runner-scale-set` and `gha-runner-scale-set-experimental`.

The error a user now gets for the case in the issue:

```
Error: execution error at (gha-runner-scale-set/templates/autoscalingrunnerset.yaml:3:4):
.Values.template.metadata.labels: invalid value "“true”" for label "dind": a valid label
value must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and
must start and end with an alphanumeric character
```

## Note on two existing tests

`TestCustomLabels` and `TestCustomAnnotations` set the ArgoCD sync-wave label to `` `"1"` `` — a Go raw string containing literal quote characters, so the rendered label value was `"1"` including the quotes. Kubernetes would have rejected that. Corrected to `1`, which is what the tests were meant to cover.

## Testing

- `go test ./charts/...`
- `helm unittest charts/gha-runner-scale-set-experimental` (36 suites, 160 tests)
- `helm lint` on both charts
- New coverage for smart-quoted values, over-length values, invalid key prefixes, invalid annotation keys, and scalar values being stringified.