### PR TITLE
Render label and annotation values as strings

### DIFF
--- a/charts/gha-runner-scale-set-experimental/templates/_autoscalingrunnerset.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_autoscalingrunnerset.tpl
@@ -32,11 +32,11 @@ Render a ResourceMeta block for AutoscalingRunnerSet spec fields.
 {{- define "autoscaling-runner-set.spec-resource-metadata" -}}
 {{- with .labels }}
 labels:
-  {{- toYaml . | nindent 2 }}
+  {{- include "string-map" . | nindent 2 }}
 {{- end }}
 {{- with .annotations }}
 annotations:
-  {{- toYaml . | nindent 2 }}
+  {{- include "string-map" . | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -5,7 +5,9 @@ scientific notation (12345678901234 -> 1.2345678901234e+13) and silently write a
 user never asked for. Integral floats are therefore formatted without an exponent.
 */}}
 {{- define "metadata-value" -}}
-{{- if and (kindIs "float64" .) (eq . (floor .)) -}}
+{{- if eq . nil -}}
+{{- "" -}}
+{{- else if and (kindIs "float64" .) (eq . (floor .)) -}}
 {{- printf "%.0f" . -}}
 {{- else -}}
 {{- printf "%v" . -}}

--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -1,4 +1,31 @@
 {{/*
+Render a single label or annotation value as a string.
+Values from a values file arrive as float64, so "%v" would turn large integers into
+scientific notation (12345678901234 -> 1.2345678901234e+13) and silently write a value the
+user never asked for. Integral floats are therefore formatted without an exponent.
+*/}}
+{{- define "metadata-value" -}}
+{{- if and (kindIs "float64" .) (eq . (floor .)) -}}
+{{- printf "%.0f" . -}}
+{{- else -}}
+{{- printf "%v" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render a labels or annotations map with all values coerced to strings.
+Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
+rendered as YAML booleans or numbers.
+*/}}
+{{- define "string-map" -}}
+{{- $out := dict -}}
+{{- range $k, $v := . -}}
+{{- $_ := set $out $k (include "metadata-value" $v) -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
+{{/*
 Create the labels for the GitHub auth secret.
 */}}
 {{- define "github-secret.labels" -}}
@@ -53,14 +80,16 @@ Reserved annotations are excluded from both levels.
 
 
 {{/*
-Takes a map of user labels and removes the ones with "actions.github.com/" prefix
+Takes a map of user labels and removes the ones with "actions.github.com/" prefix.
+Values are rendered as strings so that scalars such as `true` or `1.0` do not become
+non-string YAML values, which Kubernetes rejects for labels and annotations.
 */}}
 {{- define "apply-non-reserved-gha-labels-and-annotations" -}}
 {{- $userLabels := . -}}
 {{- $processed := dict -}}
 {{- range $key, $value := $userLabels -}}
   {{- if not (hasPrefix "actions.github.com/" $key) -}}
-    {{- $_ := set $processed $key $value -}}
+    {{- $_ := set $processed $key (include "metadata-value" $value) -}}
   {{- end -}}
 {{- end -}}
 {{- if not (empty $processed) -}}

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -55,16 +55,43 @@ app.kubernetes.io/instance: {{ include "gha-runner-scale-set.scale-set-name" . }
 {{- end }}
 
 {{/*
+Render a single label or annotation value as a string.
+Values from a values file arrive as float64, so "%v" would turn large integers into
+scientific notation (12345678901234 -> 1.2345678901234e+13) and silently write a value the
+user never asked for. Integral floats are therefore formatted without an exponent.
+*/}}
+{{- define "gha-runner-scale-set.metadataValue" -}}
+{{- if and (kindIs "float64" .) (eq . (floor .)) -}}
+{{- printf "%.0f" . -}}
+{{- else -}}
+{{- printf "%v" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render a labels or annotations map with all values coerced to strings.
+Kubernetes only accepts string values, so scalars such as `true` or `1` must not be
+rendered as YAML booleans or numbers.
+*/}}
+{{- define "gha-runner-scale-set.stringMap" -}}
+{{- $out := dict -}}
+{{- range $k, $v := . -}}
+{{- $_ := set $out $k (include "gha-runner-scale-set.metadataValue" $v) -}}
+{{- end -}}
+{{- toYaml $out -}}
+{{- end }}
+
+{{/*
 Render a ResourceMeta block for AutoscalingRunnerSet spec fields.
 */}}
 {{- define "gha-runner-scale-set.resourceMetaSpec" -}}
 {{- with .labels }}
 labels:
-  {{- toYaml . | nindent 2 }}
+  {{- include "gha-runner-scale-set.stringMap" . | nindent 2 }}
 {{- end }}
 {{- with .annotations }}
 annotations:
-  {{- toYaml . | nindent 2 }}
+  {{- include "gha-runner-scale-set.stringMap" . | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -61,7 +61,9 @@ scientific notation (12345678901234 -> 1.2345678901234e+13) and silently write a
 user never asked for. Integral floats are therefore formatted without an exponent.
 */}}
 {{- define "gha-runner-scale-set.metadataValue" -}}
-{{- if and (kindIs "float64" .) (eq . (floor .)) -}}
+{{- if eq . nil -}}
+{{- "" -}}
+{{- else if and (kindIs "float64" .) (eq . (floor .)) -}}
 {{- printf "%.0f" . -}}
 {{- else -}}
 {{- printf "%v" . -}}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -27,7 +27,7 @@ metadata:
     {{- with .Values.resourceMeta.autoscalingRunnerSet.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -38,7 +38,7 @@ metadata:
     {{- with .Values.annotations }}
     {{- range $k, $v := . }}
     {{- if not (or (hasPrefix "actions.github.com/cleanup-" $k) (eq $k "actions.github.com/values-hash")) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -46,7 +46,7 @@ metadata:
     {{- with .Values.resourceMeta.autoscalingRunnerSet.annotations }}
     {{- range $k, $v := . }}
     {{- if not (or (hasPrefix "actions.github.com/cleanup-" $k) (eq $k "actions.github.com/values-hash")) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
@@ -218,11 +218,11 @@ spec:
     metadata:
       {{- with .labels }}
       labels:
-        {{- toYaml . | nindent 8 }}
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
       {{- end }}
       {{- with .annotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
       {{- end }}
     {{- end }}
     spec:

--- a/charts/gha-runner-scale-set/templates/githubsecret.yaml
+++ b/charts/gha-runner-scale-set/templates/githubsecret.yaml
@@ -12,23 +12,23 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.githubConfigSecret.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.githubConfigSecret.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role.yaml
@@ -14,23 +14,23 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRole.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRole.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_role_binding.yaml
@@ -13,24 +13,24 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRoleBinding.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
 
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeRoleBinding.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
@@ -9,11 +9,11 @@ metadata:
   {{- if or .Values.annotations $hasCustomResourceMeta }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeServiceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   {{- end }}
@@ -24,13 +24,13 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.kubernetesModeServiceAccount.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}

--- a/charts/gha-runner-scale-set/templates/manager_role.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role.yaml
@@ -11,24 +11,24 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRole.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager-role
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRole.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
+++ b/charts/gha-runner-scale-set/templates/manager_role_binding.yaml
@@ -11,24 +11,24 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRoleBinding.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
     app.kubernetes.io/component: manager-role-binding
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.managerRoleBinding.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
+++ b/charts/gha-runner-scale-set/templates/no_permission_serviceaccount.yaml
@@ -13,23 +13,23 @@ metadata:
     {{- with .Values.labels }}
     {{- range $k, $v := . }}
     {{- if not (or (hasKey $reserved $k) (hasPrefix "actions.github.com/" $k)) }}
-    {{ $k }}: {{ $v | quote }}
+    {{ $k }}: {{ include "gha-runner-scale-set.metadataValue" $v | quote }}
     {{- end }}
     {{- end }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.noPermissionServiceAccount.labels }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
     {{- include "gha-runner-scale-set.labels" . | nindent 4 }}
   annotations:
     {{- with .Values.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- if $hasCustomResourceMeta }}
     {{- with .Values.resourceMeta.noPermissionServiceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- include "gha-runner-scale-set.stringMap" . | nindent 4 }}
     {{- end }}
     {{- end }}
   finalizers:

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -3152,3 +3152,54 @@ func TestAutoscalingRunnerSetCustomAnnotationsAndLabelsApplied(t *testing.T) {
 	assert.NotEqual(t, "not-propagated", autoscalingRunnerSet.Annotations["actions.github.com/cleanup-manager-role-name"])
 	assert.NotEqual(t, "not-propagated", autoscalingRunnerSet.Labels["app.kubernetes.io/component"])
 }
+
+func TestTemplateRenderedAutoScalingRunnerSet_ScalarMetadataValuesAreRenderedAsStrings(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	testValuesPath, err := filepath.Abs("../tests/values_scalar_metadata.yaml")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger:         logger.Discard,
+		ValuesFiles:    []string{testValuesPath},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	// UnmarshalK8SYaml fails outright if a value decodes as a bool or number rather than a
+	// string, so a successful decode is itself part of the assertion.
+	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var autoscalingRunnerSet v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &autoscalingRunnerSet)
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Labels["chart-bool"])
+	assert.Equal(t, "1", autoscalingRunnerSet.Labels["chart-int"])
+	assert.Equal(t, "false", autoscalingRunnerSet.Annotations["chart-bool-annotation"])
+	assert.Equal(t, "1.5", autoscalingRunnerSet.Annotations["chart-float-annotation"])
+	assert.Equal(t, "12345678901234", autoscalingRunnerSet.Annotations["chart-big-int-annotation"])
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Labels["pod-bool"])
+	assert.Equal(t, "42", autoscalingRunnerSet.Spec.Template.Labels["pod-int"])
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Annotations["pod-bool-annotation"])
+	assert.Equal(t, "7", autoscalingRunnerSet.Spec.Template.Annotations["pod-int-annotation"])
+
+	require.NotNil(t, autoscalingRunnerSet.Spec.EphemeralRunnerMetadata)
+	assert.Equal(t, "false", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-bool"])
+	assert.Equal(t, "3", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-int"])
+	assert.Equal(t, "9", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Annotations["runner-int-annotation"])
+
+	output = helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/githubsecret.yaml"})
+
+	var githubSecret corev1.Secret
+	helm.UnmarshalK8SYaml(t, output, &githubSecret)
+
+	assert.Equal(t, "5", githubSecret.Labels["secret-int"])
+	assert.Equal(t, "true", githubSecret.Labels["chart-bool"])
+	assert.Equal(t, "1.5", githubSecret.Annotations["chart-float-annotation"])
+}

--- a/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
+++ b/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
@@ -1,0 +1,39 @@
+githubConfigUrl: https://github.com/actions
+githubConfigSecret:
+  github_token: gh_token12345
+controllerServiceAccount:
+  name: arc
+  namespace: arc-system
+
+# Every value below is an unquoted YAML scalar, so it parses as a bool, int or float
+# rather than a string. Kubernetes only accepts string label and annotation values, so
+# the chart has to coerce these when rendering.
+labels:
+  chart-bool: true
+  chart-int: 1
+annotations:
+  chart-bool-annotation: false
+  chart-float-annotation: 1.5
+  # Large integers must not be rendered in scientific notation. Values loaded from a file
+  # arrive as float64, so a naive "%v" would produce "1.2345678901234e+13".
+  chart-big-int-annotation: 12345678901234
+
+template:
+  metadata:
+    labels:
+      pod-bool: true
+      pod-int: 42
+    annotations:
+      pod-bool-annotation: true
+      pod-int-annotation: 7
+
+resourceMeta:
+  ephemeralRunner:
+    labels:
+      runner-bool: false
+      runner-int: 3
+    annotations:
+      runner-int-annotation: 9
+  githubConfigSecret:
+    labels:
+      secret-int: 5


### PR DESCRIPTION
## The bug

Kubernetes only accepts **string** values for labels and annotations. Both `gha-runner-scale-set` and `gha-runner-scale-set-experimental` rendered metadata values with a raw `toYaml` or a bare `| quote`, so a values file like:

```yaml
annotations:
  argocd.argoproj.io/sync-wave: 1
labels:
  enabled: true
```

rendered a YAML number and a YAML boolean. The resulting manifests are rejected by the API server.

## The fix

Every metadata value now goes through a `metadataValue` helper (`gha-runner-scale-set.metadataValue` in the stable chart, `metadata-value` in the experimental one), and every metadata map through a matching `stringMap` / `string-map` helper. The two charts are deliberate mirrors with different naming conventions.

## The float64 trap

The non-obvious part, and the reason the helper is not just `printf "%v"`:

Values loaded from a `-f values.yaml` file arrive in Helm as **float64**, while `--set` yields int64/string. So `printf "%v"` turns `12345678901234` into `"1.2345678901234e+13"` — a silently corrupted value the user never asked for. Integral floats are therefore formatted with `printf "%.0f"`.

The same asymmetry means Go tests using `SetValues` **cannot** exercise this behavior at all, so the new `TestTemplateRenderedAutoScalingRunnerSet_ScalarMetadataValuesAreRenderedAsStrings` drives a real values file (`tests/values_scalar_metadata.yaml`) and asserts `chart-big-int-annotation` renders as `"12345678901234"`.

## Verification

- `go test ./charts/... -count=1` — pass
- `helm unittest charts/gha-runner-scale-set-experimental` — 176 tests pass
- `helm lint` on both charts — pass
- Mutation-tested: dropping the `%.0f` branch fails the test with `expected: "12345678901234", actual: "1.2345678901234e+13"`; reverting `stringMap` back to `toYaml` fails the decode outright. Restored, both pass.

## Stack

This is **layer 1 of a 3-PR stack** splitting #4630 into reviewable pieces. It contains string coercion only. Render-time validation of label/annotation keys and values (layer 2) and listener metadata coverage (layer 3) follow on top of this branch.