### PR TITLE
Validate and coerce listener metadata at render time

### DIFF
--- a/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_helpers.tpl
@@ -125,6 +125,13 @@ Validate every label and annotation map the chart can render onto resources it m
 {{- $runnerPod := index (.Values.runner | default dict) "pod" -}}
 {{- include "assert-map" (dict "value" $runnerPod "path" ".Values.runner.pod") -}}
 {{- include "validate-metadata" (dict "metadata" (index ($runnerPod | default dict) "metadata") "path" ".Values.runner.pod.metadata") -}}
+{{- $listener := .Values.listener | default dict -}}
+{{- if kindIs "map" $listener -}}
+{{- $listenerPod := index $listener "podTemplate" -}}
+{{- if kindIs "map" ($listenerPod | default dict) -}}
+{{- include "validate-metadata" (dict "metadata" (index ($listenerPod | default dict) "metadata") "path" ".Values.listener.podTemplate.metadata") -}}
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/gha-runner-scale-set-experimental/templates/_listener_template.tpl
+++ b/charts/gha-runner-scale-set-experimental/templates/_listener_template.tpl
@@ -5,9 +5,16 @@
   {{- fail ".Values.listener.podTemplate must have at least metadata or spec defined" -}}
 {{- end -}}
 {{- with $metadata -}}
+{{- $out := omit . "labels" "annotations" -}}
+{{- with .labels -}}
+{{- $_ := set $out "labels" (fromYaml (include "string-map" .)) -}}
+{{- end -}}
+{{- with .annotations -}}
+{{- $_ := set $out "annotations" (fromYaml (include "string-map" .)) -}}
+{{- end -}}
 metadata:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
+  {{- toYaml $out | nindent 2 }}
+{{ end }}
 {{- with $spec -}}
 spec:
   {{- $containers := (index . "containers" | default (list)) -}}

--- a/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
+++ b/charts/gha-runner-scale-set-experimental/tests/autoscaling_runner_set_metadata_validation_test.yaml
@@ -162,6 +162,25 @@ tests:
       - failedTemplate:
           errorMessage: '.Values.resource.ephemeralRunner: must be a mapping, got string'
 
+  - it: should fail when a listener pod label value is invalid
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      listener:
+        podTemplate:
+          metadata:
+            labels:
+              purpose: "“true”"
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - failedTemplate:
+          errorMessage: '.Values.listener.podTemplate.metadata.labels: invalid value "“true”" for label "purpose": a valid label value must be an empty string or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start and end with an alphanumeric character'
+
   - it: should fail when a metadata value is a mapping instead of a scalar
     set:
       scaleset.name: "test"
@@ -202,3 +221,36 @@ tests:
       - equal:
           path: spec.template.metadata.labels["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com/purpose"]
           value: "yes"
+
+  # A listener pod template carrying both metadata and spec used to render "true" and the
+  # following "spec:" key onto the same line, producing invalid YAML.
+  - it: should render listener metadata and spec together, coercing scalar values to strings
+    set:
+      scaleset.name: "test"
+      auth.url: "https://github.com/org"
+      auth.githubToken: "gh_token12345"
+      controllerServiceAccount.name: "arc"
+      controllerServiceAccount.namespace: "arc-system"
+      listener:
+        podTemplate:
+          metadata:
+            labels:
+              listener-bool: true
+            annotations:
+              listener-int: 11
+          spec:
+            containers:
+              - name: listener
+    release:
+      name: "test-name"
+      namespace: "test-namespace"
+    asserts:
+      - equal:
+          path: spec.listenerTemplate.metadata.labels.listener-bool
+          value: "true"
+      - equal:
+          path: spec.listenerTemplate.metadata.annotations.listener-int
+          value: "11"
+      - equal:
+          path: spec.listenerTemplate.spec.containers[0].name
+          value: "listener"

--- a/charts/gha-runner-scale-set/templates/_helpers.tpl
+++ b/charts/gha-runner-scale-set/templates/_helpers.tpl
@@ -183,6 +183,12 @@ Validate every label and annotation map the chart can render onto resources it m
 {{- $templateMetadata = $templateMetadata | default dict -}}
 {{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $templateMetadata "labels") "path" ".Values.template.metadata.labels") -}}
 {{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $templateMetadata "annotations") "path" ".Values.template.metadata.annotations") -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" .Values.listenerTemplate "path" ".Values.listenerTemplate") -}}
+{{- $listenerMetadata := index (.Values.listenerTemplate | default dict) "metadata" -}}
+{{- include "gha-runner-scale-set.assertMap" (dict "value" $listenerMetadata "path" ".Values.listenerTemplate.metadata") -}}
+{{- $listenerMetadata = $listenerMetadata | default dict -}}
+{{- include "gha-runner-scale-set.validateLabels" (dict "labels" (index $listenerMetadata "labels") "path" ".Values.listenerTemplate.metadata.labels") -}}
+{{- include "gha-runner-scale-set.validateAnnotations" (dict "annotations" (index $listenerMetadata "annotations") "path" ".Values.listenerTemplate.metadata.annotations") -}}
 {{- include "gha-runner-scale-set.assertMap" (dict "value" .Values.resourceMeta "path" ".Values.resourceMeta") -}}
 {{- range $resource, $meta := (.Values.resourceMeta | default dict) }}
 {{- include "gha-runner-scale-set.assertMap" (dict "value" $meta "path" (printf ".Values.resourceMeta.%s" $resource)) -}}

--- a/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
+++ b/charts/gha-runner-scale-set/templates/autoscalingrunnerset.yaml
@@ -161,7 +161,23 @@ spec:
 
   {{- with .Values.listenerTemplate }}
   listenerTemplate:
+    {{- with .metadata }}
+    metadata:
+      {{- with .labels }}
+      labels:
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
+      {{- end }}
+      {{- with .annotations }}
+      annotations:
+        {{- include "gha-runner-scale-set.stringMap" . | nindent 8 }}
+      {{- end }}
+      {{- with omit . "labels" "annotations" }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- end }}
+    {{- with omit . "metadata" }}
     {{- toYaml . | nindent 4}}
+    {{- end }}
   {{- end }}
 
   {{- with .Values.listenerMetrics }}

--- a/charts/gha-runner-scale-set/tests/template_test.go
+++ b/charts/gha-runner-scale-set/tests/template_test.go
@@ -3153,57 +3153,6 @@ func TestAutoscalingRunnerSetCustomAnnotationsAndLabelsApplied(t *testing.T) {
 	assert.NotEqual(t, "not-propagated", autoscalingRunnerSet.Labels["app.kubernetes.io/component"])
 }
 
-func TestTemplateRenderedAutoScalingRunnerSet_ScalarMetadataValuesAreRenderedAsStrings(t *testing.T) {
-	t.Parallel()
-
-	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
-	require.NoError(t, err)
-
-	testValuesPath, err := filepath.Abs("../tests/values_scalar_metadata.yaml")
-	require.NoError(t, err)
-
-	releaseName := "test-runners"
-	namespaceName := "test-" + strings.ToLower(random.UniqueID())
-
-	options := &helm.Options{
-		Logger:         logger.Discard,
-		ValuesFiles:    []string{testValuesPath},
-		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
-	}
-
-	// UnmarshalK8SYaml fails outright if a value decodes as a bool or number rather than a
-	// string, so a successful decode is itself part of the assertion.
-	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
-
-	var autoscalingRunnerSet v1alpha1.AutoscalingRunnerSet
-	helm.UnmarshalK8SYaml(t, output, &autoscalingRunnerSet)
-
-	assert.Equal(t, "true", autoscalingRunnerSet.Labels["chart-bool"])
-	assert.Equal(t, "1", autoscalingRunnerSet.Labels["chart-int"])
-	assert.Equal(t, "false", autoscalingRunnerSet.Annotations["chart-bool-annotation"])
-	assert.Equal(t, "1.5", autoscalingRunnerSet.Annotations["chart-float-annotation"])
-	assert.Equal(t, "12345678901234", autoscalingRunnerSet.Annotations["chart-big-int-annotation"])
-
-	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Labels["pod-bool"])
-	assert.Equal(t, "42", autoscalingRunnerSet.Spec.Template.Labels["pod-int"])
-	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Annotations["pod-bool-annotation"])
-	assert.Equal(t, "7", autoscalingRunnerSet.Spec.Template.Annotations["pod-int-annotation"])
-
-	require.NotNil(t, autoscalingRunnerSet.Spec.EphemeralRunnerMetadata)
-	assert.Equal(t, "false", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-bool"])
-	assert.Equal(t, "3", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-int"])
-	assert.Equal(t, "9", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Annotations["runner-int-annotation"])
-
-	output = helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/githubsecret.yaml"})
-
-	var githubSecret corev1.Secret
-	helm.UnmarshalK8SYaml(t, output, &githubSecret)
-
-	assert.Equal(t, "5", githubSecret.Labels["secret-int"])
-	assert.Equal(t, "true", githubSecret.Labels["chart-bool"])
-	assert.Equal(t, "1.5", githubSecret.Annotations["chart-float-annotation"])
-}
-
 func TestTemplateRenderedAutoScalingRunnerSet_InvalidMetadataValidationError(t *testing.T) {
 	t.Parallel()
 
@@ -3308,6 +3257,66 @@ func TestTemplateRenderedAutoScalingRunnerSet_ValidMetadataIsAccepted(t *testing
 	assert.Equal(t, "any value is allowed: ✅", autoscalingRunnerSet.Spec.Template.Annotations["example.com/an"])
 }
 
+// Kubernetes only accepts string label and annotation values. Values supplied as unquoted
+// YAML scalars parse as bools/numbers, so the chart has to coerce them when rendering.
+// SetValues always yields strings, so this has to come from a values file to be meaningful.
+func TestTemplateRenderedAutoScalingRunnerSet_ScalarMetadataValuesAreRenderedAsStrings(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	testValuesPath, err := filepath.Abs("../tests/values_scalar_metadata.yaml")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger:         logger.Discard,
+		ValuesFiles:    []string{testValuesPath},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	// UnmarshalK8SYaml fails outright if a value decodes as a bool or number rather than a
+	// string, so a successful decode is itself part of the assertion.
+	output := helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+
+	var autoscalingRunnerSet v1alpha1.AutoscalingRunnerSet
+	helm.UnmarshalK8SYaml(t, output, &autoscalingRunnerSet)
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Labels["chart-bool"])
+	assert.Equal(t, "1", autoscalingRunnerSet.Labels["chart-int"])
+	assert.Equal(t, "false", autoscalingRunnerSet.Annotations["chart-bool-annotation"])
+	assert.Equal(t, "1.5", autoscalingRunnerSet.Annotations["chart-float-annotation"])
+	assert.Equal(t, "12345678901234", autoscalingRunnerSet.Annotations["chart-big-int-annotation"])
+
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Labels["pod-bool"])
+	assert.Equal(t, "42", autoscalingRunnerSet.Spec.Template.Labels["pod-int"])
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.Template.Annotations["pod-bool-annotation"])
+	assert.Equal(t, "7", autoscalingRunnerSet.Spec.Template.Annotations["pod-int-annotation"])
+
+	require.NotNil(t, autoscalingRunnerSet.Spec.ListenerTemplate)
+	assert.Equal(t, "true", autoscalingRunnerSet.Spec.ListenerTemplate.Labels["listener-bool"])
+	assert.Equal(t, "11", autoscalingRunnerSet.Spec.ListenerTemplate.Annotations["listener-int-annotation"])
+	require.Len(t, autoscalingRunnerSet.Spec.ListenerTemplate.Spec.Containers, 1)
+	assert.Equal(t, "listener", autoscalingRunnerSet.Spec.ListenerTemplate.Spec.Containers[0].Name)
+
+	require.NotNil(t, autoscalingRunnerSet.Spec.EphemeralRunnerMetadata)
+	assert.Equal(t, "false", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-bool"])
+	assert.Equal(t, "3", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Labels["runner-int"])
+	assert.Equal(t, "9", autoscalingRunnerSet.Spec.EphemeralRunnerMetadata.Annotations["runner-int-annotation"])
+
+	output = helm.RenderTemplateContext(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/githubsecret.yaml"})
+
+	var githubSecret corev1.Secret
+	helm.UnmarshalK8SYaml(t, output, &githubSecret)
+
+	assert.Equal(t, "5", githubSecret.Labels["secret-int"])
+	assert.Equal(t, "true", githubSecret.Labels["chart-bool"])
+	assert.Equal(t, "1.5", githubSecret.Annotations["chart-float-annotation"])
+}
+
 func TestTemplateRenderedAutoScalingRunnerSet_NonMapMetadataValidationError(t *testing.T) {
 	t.Parallel()
 
@@ -3333,6 +3342,11 @@ func TestTemplateRenderedAutoScalingRunnerSet_NonMapMetadataValidationError(t *t
 			key:           "resourceMeta.githubConfigSecret",
 			value:         "oops",
 			expectedError: ".Values.resourceMeta.githubConfigSecret: must be a mapping, got string",
+		},
+		"listener metadata is not a map": {
+			key:           "listenerTemplate.metadata",
+			value:         "oops",
+			expectedError: ".Values.listenerTemplate.metadata: must be a mapping, got string",
 		},
 	}
 
@@ -3360,6 +3374,33 @@ func TestTemplateRenderedAutoScalingRunnerSet_NonMapMetadataValidationError(t *t
 			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
+}
+
+func TestTemplateRenderedAutoScalingRunnerSet_ListenerMetadataIsValidated(t *testing.T) {
+	t.Parallel()
+
+	helmChartPath, err := filepath.Abs("../../gha-runner-scale-set")
+	require.NoError(t, err)
+
+	releaseName := "test-runners"
+	namespaceName := "test-" + strings.ToLower(random.UniqueID())
+
+	options := &helm.Options{
+		Logger: logger.Discard,
+		SetValues: map[string]string{
+			"githubConfigUrl":                          "https://github.com/actions",
+			"githubConfigSecret.github_token":          "gh_token12345",
+			"controllerServiceAccount.name":            "arc",
+			"controllerServiceAccount.namespace":       "arc-system",
+			"listenerTemplate.metadata.labels.purpose": "“true”",
+			"listenerTemplate.spec.containers[0].name": "listener",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+	}
+
+	_, err = helm.RenderTemplateContextE(t, t.Context(), options, helmChartPath, releaseName, []string{"templates/autoscalingrunnerset.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `.Values.listenerTemplate.metadata.labels: invalid value "“true”" for label "purpose"`)
 }
 
 func TestTemplateRenderedAutoScalingRunnerSet_NonScalarMetadataValueValidationError(t *testing.T) {

--- a/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
+++ b/charts/gha-runner-scale-set/tests/values_scalar_metadata.yaml
@@ -37,3 +37,13 @@ resourceMeta:
   githubConfigSecret:
     labels:
       secret-int: 5
+
+listenerTemplate:
+  metadata:
+    labels:
+      listener-bool: true
+    annotations:
+      listener-int-annotation: 11
+  spec:
+    containers:
+      - name: listener


### PR DESCRIPTION
**Layer 3 of a 3-PR stack** splitting up #4630. Targets `nikola-jokic-validate-metadata` (layer 2), not `master`.

- Layer 1 — #4637 — coerce label/annotation values to strings
- Layer 2 — #4639 — validate label/annotation keys and values at render time (fixes #4372)
- **Layer 3 — this PR** — close the same gap for the listener

## The gap

Layers 1 and 2 covered chart-level and **runner** pod metadata. The listener pod template was left behind: `.Values.listenerTemplate.metadata` (stable) and `.Values.listener.podTemplate.metadata` (experimental) were still rendered with a raw `toYaml` — neither validated nor coerced.

Verified empirically: setting

```yaml
listenerTemplate:
  metadata:
    labels:
      bad: "“true”"
```

renders successfully and only fails later, when the controller creates the listener Pod. That is the **identical silent failure mode as #4372**, just on the listener instead of the runner — same bug class, so it belongs in this stack.

## Changes

Both charts now route listener `labels`/`annotations` through the string-map helper and validate them alongside the existing chart and runner metadata checks. An invalid value now fails at `helm template` time with a message naming the values path:

```
.Values.listenerTemplate.metadata.labels: invalid value "“true”" for label "purpose": a valid label value must be ...
.Values.listener.podTemplate.metadata.labels: invalid value "“true”" for label "purpose": a valid label value must be ...
```

In the experimental chart the listener validation is guarded with a plain `kindIs "map"` test rather than `assert-map`. The chart already has its own checks that own the `.Values.listener must be an object` messages; `assert-map` would shadow them and change the message, so the pre-existing checks keep reporting for themselves.

## Separate: pre-existing YAML bug fix

`charts/gha-runner-scale-set-experimental/templates/_listener_template.tpl` had a bug **unrelated to this feature** and predating the stack. When `listener.podTemplate` carried **both** `metadata` and `spec`, the last metadata value and the following `spec:` key rendered onto the same line — literally `listener-bool: truespec:` — which is invalid YAML.

It sits in the exact block being modified here, so it is fixed in this PR: the metadata block now ends with `{{ end }}` instead of `{{- end }}`, preserving the newline. A regression test asserts metadata and spec render together correctly, and was mutation-tested — restoring `{{- end }}` fails it with `yaml: line 34: mapping values are not allowed in this context`.

Please review this as a distinct fix from the listener validation feature.

## Verification

- `go test ./charts/... -count=1` — pass
- `helm unittest charts/gha-runner-scale-set-experimental` — 188/188 pass, confirming the two pre-existing `.Values.listener` message tests are not regressed
- `helm lint` on both charts — clean
- Both charts rendered with listener metadata **and** spec together with scalar values, piped through a YAML parser: every document parses, and every label/annotation value comes out as a quoted string
- Non-map `listenerTemplate` / `listenerTemplate.metadata` produce the path-based `must be a mapping, got string` error rather than an opaque `omit` failure

## Stack integrity

As the top of the stack, this branch's chart tree is content-identical to #4630's head:

```
$ git diff --stat refs/pr-stack/source/4630 HEAD -- charts/gha-runner-scale-set charts/gha-runner-scale-set-experimental
(empty)
```

The only whole-tree difference is rebase drift: the stack sits on a newer `master` than the source PR, so it additionally contains master commit `5e540b6c` (max-concurrent-reconciles flags). That was verified to be exactly the difference — the residual diff is byte-identical to `git diff 5e540b6c^ 5e540b6c`, and `5e540b6c` is not an ancestor of the source PR. No hunk was dropped or altered.